### PR TITLE
feat!:new api

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       - name: go test
-        run: go test -v -race
+        run: go test -run="^Test" -v -race ./...
 
   go-fuzz:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .vscode/
 .fleet/
 .idea/
+
+.tmp/

--- a/castix.go
+++ b/castix.go
@@ -1,64 +1,40 @@
 package castix
 
-import "sync"
+import (
+	"github.com/einouqo/castix/internal/bridge"
+	"github.com/einouqo/castix/internal/emit"
+	"github.com/einouqo/castix/internal/mux"
+)
 
-type control struct {
-    drain bool
+type Leave = bridge.Leave
+
+type Convert[IN, OUT any] func(IN) OUT
+
+var _ = bridge.Convert[struct{}, struct{}](Convert[struct{}, struct{}](nil))
+
+func Pass[T any](in T) T { return in }
+
+var (
+	_ Convert[struct{}, struct{}] = Pass[struct{}]
+)
+
+type Castix[IN, OUT any] struct {
+	bridge *bridge.Brigde[IN, OUT]
 }
 
-type Castix[T any] struct {
-    mu   sync.RWMutex
-    subs map[chan T]control
+func New[IN, OUT any](cv Convert[IN, OUT]) *Castix[IN, OUT] {
+	return &Castix[IN, OUT]{
+		bridge: bridge.New[IN, OUT](
+			mux.NewInput[IN](), emit.NewOutput[OUT](),
+			bridge.Convert[IN, OUT](cv),
+		),
+	}
 }
 
-func New[T any]() *Castix[T] {
-    return &Castix[T]{
-        subs: make(map[chan T]control),
-    }
+func (x Castix[IN, OUT]) Source(ch <-chan IN, opts ...SourceOption) Leave {
+	return x.bridge.Attach(ch, opts...)
 }
 
-type Cancel func()
-
-func (x *Castix[T]) C(opts ...Option) (<-chan T, Cancel) {
-    ch := make(chan T, 1)
-    ctr := control{}
-    for _, opt := range opts {
-        opt.apply(&ctr)
-    }
-
-    x.mu.Lock()
-    x.subs[ch] = ctr
-    x.mu.Unlock()
-
-    return ch, func() {
-        x.mu.Lock()
-        defer x.mu.Unlock()
-        if _, hit := x.subs[ch]; hit {
-            close(ch)
-            delete(x.subs, ch)
-        }
-    }
-}
-
-func (x *Castix[T]) Notify(msg T) {
-    x.mu.RLock()
-    defer x.mu.RUnlock()
-    for ch, ctr := range x.subs {
-        if !ctr.drain {
-            ch <- msg
-            continue
-        }
-
-        select {
-        case ch <- msg:
-            continue
-        default:
-        }
-
-        select {
-        case ch <- msg:
-        case <-ch:
-            ch <- msg
-        }
-    }
+func (x Castix[IN, OUT]) Subscribe(opts ...SubscribeOption) (<-chan OUT, Leave) {
+	return x.bridge.Watch(opts...)
 }

--- a/castix.go
+++ b/castix.go
@@ -1,7 +1,7 @@
 package castix
 
 import (
-	"github.com/einouqo/castix/internal/bridge"
+  "github.com/einouqo/castix/internal/bridge"
 	"github.com/einouqo/castix/internal/emit"
 	"github.com/einouqo/castix/internal/mux"
 )
@@ -19,7 +19,7 @@ var (
 )
 
 type Castix[IN, OUT any] struct {
-	bridge *bridge.Brigde[IN, OUT]
+	bridge *bridge.Bridge[IN, OUT]
 }
 
 func New[IN, OUT any](cv Convert[IN, OUT]) *Castix[IN, OUT] {

--- a/castix_test.go
+++ b/castix_test.go
@@ -1,167 +1,192 @@
 package castix
 
 import (
-    "sync"
-    "testing"
+	"context"
+	"sync"
+	"testing"
 )
 
 func FuzzCastixCancel(f *testing.F) {
-    f.Add(1)
+	f.Add(1)
 
-    f.Fuzz(func(t *testing.T, count int) {
-        x := New[byte]()
-        ch, cancel := x.C()
-        cancel()
+	f.Fuzz(func(t *testing.T, count int) {
+		x := New[struct{}, struct{}](Pass[struct{}])
+		ch, leave := x.Subscribe()
+		leave()
 
-        for i := 0; i < count; i++ {
-            cancel()
-        }
+		for i := 0; i < count; i++ {
+			leave()
+		}
 
-        if _, open := <-ch; open {
-            t.Fatal("channel is still open")
-        }
-    })
-}
-
-func TestCastix(t *testing.T) {
-    t.Run("safe cancel", func(t *testing.T) {
-        x := New[byte]()
-        _, cancel := x.C()
-        cancel()
-        cancel()
-    })
-
-    t.Run("notify", func(t *testing.T) {
-        x := New[byte]()
-
-        msgs := []byte{1, 2, 3}
-
-        tests := []struct {
-            name  string
-            count int
-        }{
-            {name: "no one", count: 0},
-            {name: "one", count: 1},
-            {name: "few", count: 9},
-            {name: "more", count: 10},
-        }
-
-        for _, test := range tests {
-            t.Run(test.name, func(t *testing.T) {
-                chs := make(map[<-chan byte]Cancel)
-
-                for i := 0; i < test.count; i++ {
-                    ch, cancel := x.C()
-                    chs[ch] = cancel
-                }
-
-                var wg sync.WaitGroup
-
-                wg.Add(1)
-                go func() {
-                    defer wg.Done()
-                    for _, msg := range msgs {
-                        x.Notify(msg)
-                    }
-                }()
-
-                for ch, cancel := range chs {
-                    wg.Add(1)
-                    go func(ch <-chan byte, cancel Cancel) {
-                        defer wg.Done()
-                        defer cancel()
-                        for _, msg := range msgs {
-                            r, ok := <-ch
-                            if !ok {
-                                t.Error("channel is closed")
-                            }
-                            if r != msg {
-                                t.Errorf("received wrong message (want: %d, got: %d)", msg, r)
-                            }
-                        }
-                    }(ch, cancel)
-                }
-
-                wg.Wait()
-                if c := len(x.subs); c != 0 {
-                    t.Errorf("inspection failed (expect 0 subscribers, got %d)", c)
-                }
-            })
-        }
-
-    })
-
-    t.Run("drain", func(t *testing.T) {
-        x := New[byte]()
-
-        drain, last := []byte{1, 2, 3}, byte(4)
-
-        ch, cancel := x.C(WithDrain())
-
-        for _, msg := range drain {
-            x.Notify(msg)
-        }
-        x.Notify(last)
-
-        cancel()
-        if msg := <-ch; msg != last {
-            t.Errorf("last message should be %d but got %d", last, msg)
-        }
-        if _, ok := <-ch; ok {
-            t.Errorf("subscribe channel should be closed after cancel and read last")
-        }
-    })
+		if _, open := <-ch; open {
+			t.Fatal("channel is still open")
+		}
+	})
 }
 
 func BenchmarkCastix(b *testing.B) {
-    b.Run("notify", func(b *testing.B) {
-        benches := []struct {
-            name  string
-            count int
-        }{
-            {name: "no one", count: 0},
-            {name: "one", count: 1},
-            {name: "few", count: 1 << 2},
-            {name: "more", count: 1 << 4},
-            {name: "even more", count: 1 << 8},
-            {name: "a lot", count: 1 << 16},
-        }
+	b.Run("static", func(b *testing.B) {
+		type run func(b *testing.B, n int)
+		type runner func(b *testing.B, f run)
 
-        for _, bench := range benches {
-            x := New[int]()
-            cancels := make([]Cancel, 0, bench.count)
+		runners := []runner{
+			func(b *testing.B, f run) { b.Run("no one", func(b *testing.B) { f(b, 0) }) },
+			func(b *testing.B, f run) { b.Run("one", func(b *testing.B) { f(b, 1) }) },
+			func(b *testing.B, f run) { b.Run("few", func(b *testing.B) { f(b, 1<<2) }) },
+			func(b *testing.B, f run) { b.Run("more", func(b *testing.B) { f(b, 1<<4) }) },
+			func(b *testing.B, f run) { b.Run("even more", func(b *testing.B) { f(b, 1<<8) }) },
+			func(b *testing.B, f run) { b.Run("a lot", func(b *testing.B) { f(b, 1<<10) }) },
+		}
 
-            var wg sync.WaitGroup
-            for i := 0; i < bench.count; i++ {
-                ch, cancel := x.C()
-                cancels = append(cancels, cancel)
+		b.Run("inputs", func(b *testing.B) {
+			for _, rr := range runners {
+				rr(b, func(b *testing.B, n int) {
+					x := New[int, int](Pass[int])
 
-                wg.Add(1)
-                go func(ch <-chan int) {
-                    defer wg.Done()
-                    for range ch {
-                    }
-                }(ch)
-            }
+					ctx := context.Background()
+					ctx, cancel := context.WithCancel(ctx)
 
-            b.Run(bench.name, func(b *testing.B) {
-                for i := 0; i < b.N; i++ {
-                    x.Notify(i)
-                }
-            })
+					wg := sync.WaitGroup{}
 
-            for _, cancel := range cancels {
-                cancel()
-            }
-            wg.Wait()
-        }
-    })
+					for i := 0; i < n; i++ {
+						wg.Add(1)
+						go func() {
+							defer wg.Done()
 
-    b.Run("rapid notify", func(b *testing.B) {
-        b.Skip("implement me")
-    })
+							in := make(chan int)
+							defer close(in)
 
-    b.Run("runtime ops", func(b *testing.B) {
-        b.Skip("implement me")
-    })
+							leave := x.Source(in)
+							defer leave()
+
+							for i := 0; i <= b.N; i++ {
+								in <- i
+							}
+						}()
+					}
+
+					done := make(chan struct{})
+					go func(ctx context.Context) {
+						defer close(done)
+						ch, leave := x.Subscribe()
+						defer leave()
+
+						for {
+							select {
+							case <-ch:
+							case <-ctx.Done():
+								return
+							}
+						}
+					}(ctx)
+
+					wg.Wait()
+					cancel()
+					<-done
+				})
+			}
+		})
+
+		b.Run("outputs", func(b *testing.B) {
+			for _, rr := range runners {
+				rr(b, func(b *testing.B, n int) {
+					x := New[int, int](Pass[int])
+
+					ctx := context.Background()
+					ctx, cancel := context.WithCancel(ctx)
+
+					wg := sync.WaitGroup{}
+
+					for i := 0; i < n; i++ {
+						wg.Add(1)
+						go func(ctx context.Context) {
+							defer wg.Done()
+
+							ch, leave := x.Subscribe()
+							defer leave()
+
+							for {
+								select {
+								case <-ch:
+								case <-ctx.Done():
+									return
+								}
+							}
+						}(ctx)
+					}
+
+					in := make(chan int)
+					defer close(in)
+
+					leave := x.Source(in)
+					defer leave()
+
+					for i := 0; i < b.N; i++ {
+						in <- i
+					}
+
+					cancel()
+					wg.Wait()
+				})
+			}
+		})
+
+		b.Run("input-output", func(b *testing.B) {
+			for _, runner := range runners {
+				runner(b, func(b *testing.B, n int) {
+					x := New[int, int](Pass[int])
+
+					ctx := context.Background()
+					ctx, cancel := context.WithCancel(ctx)
+
+					og := sync.WaitGroup{}
+
+					for i := 0; i < n; i++ {
+						og.Add(1)
+						go func(ctx context.Context) {
+							defer og.Done()
+
+							ch, leave := x.Subscribe()
+							defer leave()
+
+							for {
+								select {
+								case <-ch:
+								case <-ctx.Done():
+									return
+								}
+							}
+						}(ctx)
+					}
+
+					sg := sync.WaitGroup{}
+
+					for i := 0; i <= n; i++ {
+						sg.Add(1)
+						go func() {
+							defer sg.Done()
+
+							in := make(chan int)
+							defer close(in)
+
+							leave := x.Source(in)
+							defer leave()
+
+							for i := 0; i <= b.N; i++ {
+								in <- i
+							}
+						}()
+					}
+
+					sg.Wait()
+					cancel()
+					og.Wait()
+				})
+			}
+		})
+	})
+
+	b.Run("dynamic", func(b *testing.B) {
+		b.Skip("implement me")
+	})
 }

--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -1,6 +1,6 @@
 package bridge
 
-type Brigde[IN, OUT any] struct {
+type Bridge[IN, OUT any] struct {
 	in  Input[IN]
 	out Output[OUT]
 
@@ -10,14 +10,14 @@ type Brigde[IN, OUT any] struct {
 func New[IN, OUT any](
 	in Input[IN], out Output[OUT],
 	cv Convert[IN, OUT],
-) *Brigde[IN, OUT] {
-	return &Brigde[IN, OUT]{
+) *Bridge[IN, OUT] {
+	return &Bridge[IN, OUT]{
 		in: in, out: out,
 		cv: cv,
 	}
 }
 
-func (b Brigde[IN, OUT]) Attach(ch <-chan IN, options ...AttachOption) Leave {
+func (b Bridge[IN, OUT]) Attach(ch <-chan IN, options ...AttachOption) Leave {
 	opts := make([]InputAttachOption, 0, len(options)+1)
 	for _, option := range options {
 		opts = append(opts, option)
@@ -25,7 +25,7 @@ func (b Brigde[IN, OUT]) Attach(ch <-chan IN, options ...AttachOption) Leave {
 	return b.in.Attach(ch, func(in IN) { b.out.Pass(b.cv(in)) }, opts...)
 }
 
-func (b Brigde[IN, OUT]) Watch(options ...WatchOption) (<-chan OUT, Leave) {
+func (b Bridge[IN, OUT]) Watch(options ...WatchOption) (<-chan OUT, Leave) {
 	opts := make([]OutputWatchOption, 0, len(options))
 	for _, option := range options {
 		opts = append(opts, option)

--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -22,8 +22,7 @@ func (b Brigde[IN, OUT]) Attach(ch <-chan IN, options ...AttachOption) Leave {
 	for _, option := range options {
 		opts = append(opts, option)
 	}
-	opts = append(opts, WithAttachHandle(func(in IN) { b.out.Pass(b.cv(in)) }))
-	return b.in.Attach(ch, opts...)
+	return b.in.Attach(ch, func(in IN) { b.out.Pass(b.cv(in)) }, opts...)
 }
 
 func (b Brigde[IN, OUT]) Watch(options ...WatchOption) (<-chan OUT, Leave) {

--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -1,0 +1,35 @@
+package bridge
+
+type Brigde[IN, OUT any] struct {
+	in  Input[IN]
+	out Output[OUT]
+
+	cv Convert[IN, OUT]
+}
+
+func New[IN, OUT any](
+	in Input[IN], out Output[OUT],
+	cv Convert[IN, OUT],
+) *Brigde[IN, OUT] {
+	return &Brigde[IN, OUT]{
+		in: in, out: out,
+		cv: cv,
+	}
+}
+
+func (b Brigde[IN, OUT]) Attach(ch <-chan IN, options ...AttachOption) Leave {
+	opts := make([]InputAttachOption, 0, len(options)+1)
+	for _, option := range options {
+		opts = append(opts, option)
+	}
+	opts = append(opts, WithAttachHandle(func(in IN) { b.out.Pass(b.cv(in)) }))
+	return b.in.Attach(ch, opts...)
+}
+
+func (b Brigde[IN, OUT]) Watch(options ...WatchOption) (<-chan OUT, Leave) {
+	opts := make([]OutputWatchOption, 0, len(options))
+	for _, option := range options {
+		opts = append(opts, option)
+	}
+	return b.out.Watch(opts...)
+}

--- a/internal/bridge/input.go
+++ b/internal/bridge/input.go
@@ -1,0 +1,31 @@
+package bridge
+
+type Input[T any] interface {
+  Attach(<-chan T, ...InputAttachOption) Leave
+}
+
+type AttachHandleOption[T any] Handle[T]
+
+func (AttachHandleOption[T]) itsInputAttachOption() {}
+
+func WithAttachHandle[T any](handle Handle[T]) AttachHandleOption[T] {
+  return AttachHandleOption[T](handle)
+}
+
+type AttachFilterOption[T any] Filter[T]
+
+func WithAttachFilter[T any](f Filter[T]) AttachFilterOption[T] {
+  return AttachFilterOption[T](f)
+}
+
+func (AttachFilterOption[T]) itsInputAttachOption() {}
+func (AttachFilterOption[T]) itsAttachOption()      {}
+
+type InputAttachOption interface {
+  itsInputAttachOption()
+}
+
+var (
+  _ InputAttachOption = (*AttachHandleOption[struct{}])(nil)
+  _ InputAttachOption = (*AttachFilterOption[struct{}])(nil)
+)

--- a/internal/bridge/input.go
+++ b/internal/bridge/input.go
@@ -1,17 +1,8 @@
 package bridge
 
 type Input[T any] interface {
-  Attach(<-chan T, ...InputAttachOption) Leave
+  Attach(<-chan T, Handle[T], ...InputAttachOption) Leave
 }
-
-type AttachHandleOption[T any] Handle[T]
-
-func (AttachHandleOption[T]) itsInputAttachOption() {}
-
-func WithAttachHandle[T any](handle Handle[T]) AttachHandleOption[T] {
-  return AttachHandleOption[T](handle)
-}
-
 type AttachFilterOption[T any] Filter[T]
 
 func WithAttachFilter[T any](f Filter[T]) AttachFilterOption[T] {
@@ -26,6 +17,5 @@ type InputAttachOption interface {
 }
 
 var (
-  _ InputAttachOption = (*AttachHandleOption[struct{}])(nil)
   _ InputAttachOption = (*AttachFilterOption[struct{}])(nil)
 )

--- a/internal/bridge/option.go
+++ b/internal/bridge/option.go
@@ -1,0 +1,22 @@
+package bridge
+
+type AttachOption interface {
+	InputAttachOption
+	itsAttachOption()
+}
+
+var (
+	_ AttachOption = (*AttachFilterOption[struct{}])(nil)
+)
+
+type WatchOption interface {
+	OutputWatchOption
+	itsWatchOption()
+}
+
+var (
+	_ WatchOption = (*WatchBufferSizeOption)(nil)
+	_ WatchOption = (*WatchDrainOption)(nil)
+	_ WatchOption = (*WatchSkipOption)(nil)
+	_ WatchOption = (*WatchFilterOption[struct{}])(nil)
+)

--- a/internal/bridge/output.go
+++ b/internal/bridge/output.go
@@ -1,0 +1,48 @@
+package bridge
+
+type Output[T any] interface {
+  Pass(T)
+  Watch(...OutputWatchOption) (<-chan T, Leave)
+}
+
+type WatchBufferSizeOption int
+
+func (WatchBufferSizeOption) itsOutputWatchOption() {}
+func (WatchBufferSizeOption) itsWatchOption()       {}
+
+func WithWatchBuffSize(size int) WatchBufferSizeOption {
+  return WatchBufferSizeOption(size)
+}
+
+type WatchDrainOption struct{}
+
+func (WatchDrainOption) itsOutputWatchOption() {}
+func (WatchDrainOption) itsWatchOption()       {}
+
+func WithWatchDrain() (opt WatchDrainOption) { return opt }
+
+type WatchSkipOption struct{}
+
+func (WatchSkipOption) itsOutputWatchOption() {}
+func (WatchSkipOption) itsWatchOption()       {}
+
+func WithWatchSkip() (opt WatchSkipOption) { return opt }
+
+type WatchFilterOption[T any] Filter[T]
+
+func (WatchFilterOption[T]) itsOutputWatchOption() {}
+func (WatchFilterOption[T]) itsWatchOption()       {}
+
+func WithWatchFilter[T any](f Filter[T]) WatchFilterOption[T] {
+  return WatchFilterOption[T](f)
+}
+
+type OutputWatchOption interface {
+  itsOutputWatchOption()
+}
+
+var (
+  _ OutputWatchOption = (*WatchBufferSizeOption)(nil)
+  _ OutputWatchOption = (*WatchDrainOption)(nil)
+  _ OutputWatchOption = (*WatchSkipOption)(nil)
+)

--- a/internal/bridge/type.go
+++ b/internal/bridge/type.go
@@ -1,0 +1,9 @@
+package bridge
+
+type Leave func()
+
+type Convert[IN, OUT any] func(IN) OUT
+
+type Handle[T any] func(T)
+
+type Filter[T any] func(T) bool

--- a/internal/emit/bridge.go
+++ b/internal/emit/bridge.go
@@ -1,0 +1,38 @@
+package emit
+
+import "github.com/einouqo/castix/internal/bridge"
+
+type Output[T any] struct{ emitter[T] }
+
+var (
+  _ bridge.Output[struct{}] = (*Output[struct{}])(nil)
+)
+
+func (o *Output[T]) init() *Output[T] {
+  o.emitter.init()
+  return o
+}
+
+func NewOutput[T any]() *Output[T] {
+  return new(Output[T]).init()
+}
+
+func (o *Output[T]) Pass(msg T) { o.emit(msg) }
+
+func (o *Output[T]) Watch(options ...bridge.OutputWatchOption) (<-chan T, bridge.Leave) {
+  opts := make([]option, 0, len(options))
+  for _, option := range options {
+    switch opt := option.(type) {
+    case bridge.WatchBufferSizeOption:
+      opts = append(opts, withBuffSize(int(opt)))
+    case bridge.WatchSkipOption:
+      opts = append(opts, withStrategy(skipping))
+    case bridge.WatchDrainOption:
+      opts = append(opts, withStrategy(draining))
+    case bridge.WatchFilterOption[T]:
+      // TODO: implement me
+      panic("implement me")
+    }
+  }
+  return o.watch(opts...)
+}

--- a/internal/emit/bridge.go
+++ b/internal/emit/bridge.go
@@ -21,8 +21,8 @@ func (o *Output[T]) Pass(msg T) { o.emit(msg) }
 
 func (o *Output[T]) Watch(options ...bridge.OutputWatchOption) (<-chan T, bridge.Leave) {
   opts := make([]option, 0, len(options))
-  for _, option := range options {
-    switch opt := option.(type) {
+  for _, opt := range options {
+    switch opt := opt.(type) {
     case bridge.WatchBufferSizeOption:
       opts = append(opts, withBuffSize(int(opt)))
     case bridge.WatchSkipOption:
@@ -30,8 +30,7 @@ func (o *Output[T]) Watch(options ...bridge.OutputWatchOption) (<-chan T, bridge
     case bridge.WatchDrainOption:
       opts = append(opts, withStrategy(draining))
     case bridge.WatchFilterOption[T]:
-      // TODO: implement me
-      panic("implement me")
+      opts = append(opts, withFilter[T](opt))
     }
   }
   return o.watch(opts...)

--- a/internal/emit/bridge.go
+++ b/internal/emit/bridge.go
@@ -30,7 +30,7 @@ func (o *Output[T]) Watch(options ...bridge.OutputWatchOption) (<-chan T, bridge
     case bridge.WatchDrainOption:
       opts = append(opts, withStrategy(draining))
     case bridge.WatchFilterOption[T]:
-      opts = append(opts, withFilter[T](opt))
+      opts = append(opts, withFilter[T](filter[T](opt)))
     }
   }
   return o.watch(opts...)

--- a/internal/emit/build.go
+++ b/internal/emit/build.go
@@ -34,7 +34,7 @@ func build[T any](done <-chan struct{}, opts ...option) (chan T, deliver[T]) {
   s := new(settings[T]).init()
   for _, opt := range opts {
     switch opt := opt.(type) {
-    case configue:
+    case configure:
       opt(&s.config)
     case setup[T]:
       opt(s)

--- a/internal/emit/config.go
+++ b/internal/emit/config.go
@@ -1,0 +1,37 @@
+package emit
+
+type strategy uint8
+
+const (
+  _ strategy = iota
+  draining
+  skipping
+)
+
+type config struct {
+  size     int
+  strategy strategy
+}
+
+func (c *config) init() *config {
+  c.size = 1
+  return c
+}
+
+func build[T any](done chan struct{}, opts ...option) (chan T, deliver[T]) {
+  cfg := new(config).init()
+  for _, opt := range opts {
+    opt(cfg)
+  }
+
+  ch, dlv := make(chan T, cfg.size), send[T](done)
+
+  switch cfg.strategy {
+  case draining:
+    dlv = drain[T](done)
+  case skipping:
+    dlv = skip[T](done)
+  }
+
+  return ch, dlv
+}

--- a/internal/emit/delivery.go
+++ b/internal/emit/delivery.go
@@ -1,0 +1,40 @@
+package emit
+
+type deliver[T any] func(chan T, T)
+
+func send[T any](done <-chan struct{}) deliver[T] {
+	return func(ch chan T, msg T) {
+		select {
+		case ch <- msg:
+		case <-done:
+		}
+	}
+}
+
+func skip[T any](_ <-chan struct{}) deliver[T] {
+	return func(ch chan T, msg T) {
+		select {
+		case ch <- msg:
+		default:
+		}
+	}
+}
+
+func drain[T any](done <-chan struct{}) deliver[T] {
+	return func(ch chan T, msg T) {
+		select {
+		case ch <- msg:
+			return
+		default:
+		}
+
+		select {
+		case ch <- msg:
+		case <-ch:
+			select {
+			case ch <- msg:
+			case <-done:
+			}
+		}
+	}
+}

--- a/internal/emit/emitter.go
+++ b/internal/emit/emitter.go
@@ -1,0 +1,55 @@
+package emit
+
+import (
+  "sync"
+  "sync/atomic"
+)
+
+var cil = (chan struct{})(nil)
+
+type emitter[T any] struct {
+  mu   sync.RWMutex
+  outs map[chan T]deliver[T]
+}
+
+func (e *emitter[T]) init() *emitter[T] {
+  e.outs = make(map[chan T]deliver[T])
+  return e
+}
+
+func (e *emitter[T]) emit(msg T) {
+  e.mu.RLock()
+  defer e.mu.RUnlock()
+  for out, dlv := range e.outs {
+    dlv(out, msg)
+  }
+}
+
+func (e *emitter[T]) watch(opts ...option) (c <-chan T, stop func()) {
+  done := atomic.Value{}
+  done.Store(make(chan struct{}))
+
+  ch, dlv := build[T](
+    done.Load().(chan struct{}),
+    opts...,
+  )
+
+  e.mu.Lock()
+  e.outs[ch] = dlv
+  e.mu.Unlock()
+
+  return ch, func() {
+    d := done.Swap(cil).(chan struct{})
+    if d == cil {
+      return // already stopped
+    }
+    close(d)
+
+    e.mu.Lock()
+    defer e.mu.Unlock()
+    if _, hit := e.outs[ch]; hit {
+      close(ch)
+      delete(e.outs, ch)
+    }
+  }
+}

--- a/internal/emit/emitter_test.go
+++ b/internal/emit/emitter_test.go
@@ -1,0 +1,100 @@
+package emit
+
+import (
+  "sync"
+  "testing"
+)
+
+func TestEmitter(t *testing.T) {
+  t.Run("emit", func(t *testing.T) {
+    p := new(emitter[byte]).init()
+
+    msgs := []byte{1, 2, 3}
+
+    tests := []struct {
+      name  string
+      count int
+    }{
+      {name: "no one", count: 0},
+      {name: "one", count: 1},
+      {name: "few", count: 9},
+      {name: "more", count: 10},
+    }
+
+    for _, test := range tests {
+      t.Run(test.name, func(t *testing.T) {
+        chs := make(map[<-chan byte]func())
+
+        for i := 0; i < test.count; i++ {
+          ch, stop := p.watch()
+          chs[ch] = stop
+        }
+
+        var wg sync.WaitGroup
+
+        wg.Add(1)
+        go func() {
+          defer wg.Done()
+          for _, msg := range msgs {
+            p.emit(msg)
+          }
+        }()
+
+        for ch, cancel := range chs {
+          wg.Add(1)
+          go func(ch <-chan byte, stop func()) {
+            defer wg.Done()
+            defer stop()
+            for _, msg := range msgs {
+              r, ok := <-ch
+              if !ok {
+                t.Error("channel is closed")
+              }
+              if r != msg {
+                t.Errorf("received wrong message (want: %d, got: %d)", msg, r)
+              }
+            }
+          }(ch, cancel)
+        }
+
+        wg.Wait()
+        if c := len(p.outs); c != 0 {
+          t.Errorf("inspection failed (expect 0 subscribers, got %d)", c)
+        }
+      })
+    }
+  })
+
+  t.Run("strategy", func(t *testing.T) {
+    p := new(emitter[byte]).init()
+
+    msgs := []byte{1, 2, 3}
+
+    tests := []struct {
+      name     string
+      strategy strategy
+      expect   byte
+    }{
+      {name: "skipping", strategy: skipping, expect: 1},
+      {name: "draining", strategy: draining, expect: 3},
+    }
+
+    for _, test := range tests {
+      t.Run(test.name, func(t *testing.T) {
+        ch, stop := p.watch(withStrategy(test.strategy))
+
+        for _, msg := range msgs {
+          p.emit(msg)
+        }
+
+        stop()
+        if msg := <-ch; msg != test.expect {
+          t.Errorf("message should be %d but got %d", test.expect, msg)
+        }
+        if _, ok := <-ch; ok {
+          t.Errorf("subscribe channel should be closed after stop and read last")
+        }
+      })
+    }
+  })
+}

--- a/internal/emit/emitter_test.go
+++ b/internal/emit/emitter_test.go
@@ -124,7 +124,7 @@ func TestEmitter(t *testing.T) {
             e.emit(msg)
           }
         }()
-        
+
         for i, msg := range test.expect {
           r, ok := <-ch
           if !ok {

--- a/internal/emit/option.go
+++ b/internal/emit/option.go
@@ -2,7 +2,9 @@ package emit
 
 type configue func(*config)
 
-var _ option = configue(nil)
+var (
+  _ option = configue(nil)
+)
 
 func (configue) itsOption() {}
 
@@ -15,14 +17,20 @@ func withBuffSize(size int) configue {
 }
 
 func withStrategy(s strategy) configue {
-  return func(c *config) { c.strategy = s }
+  return func(c *config) { c.strat = s }
 }
 
-type withFilter[T any] filter[T]
+type setup[T any] func(*settings[T])
 
-var _ option = withFilter[struct{}](nil)
+var (
+  _ option = setup[struct{}](nil)
+)
 
-func (withFilter[T]) itsOption() {}
+func (s setup[T]) itsOption() {}
+
+func withFilter[T any](f filter[T]) setup[T] {
+  return func(s *settings[T]) { s.filter = f }
+}
 
 type option interface {
   itsOption()

--- a/internal/emit/option.go
+++ b/internal/emit/option.go
@@ -1,14 +1,14 @@
 package emit
 
-type configue func(*config)
+type configure func(*config)
 
 var (
-  _ option = configue(nil)
+  _ option = configure(nil)
 )
 
-func (configue) itsOption() {}
+func (configure) itsOption() {}
 
-func withBuffSize(size int) configue {
+func withBuffSize(size int) configure {
   return func(c *config) {
     if size >= 1 {
       c.size = size
@@ -16,7 +16,7 @@ func withBuffSize(size int) configue {
   }
 }
 
-func withStrategy(s strategy) configue {
+func withStrategy(s strategy) configure {
   return func(c *config) { c.strat = s }
 }
 

--- a/internal/emit/option.go
+++ b/internal/emit/option.go
@@ -1,0 +1,15 @@
+package emit
+
+type option func(*config)
+
+func withBuffSize(size int) option {
+  return func(c *config) {
+    if size >= 1 {
+      c.size = size
+    }
+  }
+}
+
+func withStrategy(s strategy) option {
+  return func(c *config) { c.strategy = s }
+}

--- a/internal/emit/option.go
+++ b/internal/emit/option.go
@@ -1,8 +1,12 @@
 package emit
 
-type option func(*config)
+type configue func(*config)
 
-func withBuffSize(size int) option {
+var _ option = configue(nil)
+
+func (configue) itsOption() {}
+
+func withBuffSize(size int) configue {
   return func(c *config) {
     if size >= 1 {
       c.size = size
@@ -10,6 +14,16 @@ func withBuffSize(size int) option {
   }
 }
 
-func withStrategy(s strategy) option {
+func withStrategy(s strategy) configue {
   return func(c *config) { c.strategy = s }
+}
+
+type withFilter[T any] filter[T]
+
+var _ option = withFilter[struct{}](nil)
+
+func (withFilter[T]) itsOption() {}
+
+type option interface {
+  itsOption()
 }

--- a/internal/mux/bridge.go
+++ b/internal/mux/bridge.go
@@ -17,25 +17,17 @@ func NewInput[T any]() *Input[T] {
   return new(Input[T]).init()
 }
 
-func (in *Input[T]) Attach(ch <-chan T, options ...bridge.InputAttachOption) bridge.Leave {
-  var (
-    f bridge.Filter[T]
-    h bridge.Handle[T]
-  )
-  for _, option := range options {
-    switch opt := option.(type) {
+func (in *Input[T]) Attach(ch <-chan T, h bridge.Handle[T], opts ...bridge.InputAttachOption) bridge.Leave {
+  var f bridge.Filter[T]
+  for _, opt := range opts {
+    switch opt := opt.(type) {
     case bridge.AttachFilterOption[T]:
       f = bridge.Filter[T](opt)
-    case bridge.AttachHandleOption[T]:
-      h = bridge.Handle[T](opt)
     }
   }
 
   return in.attach(ch, func(msg T) {
     if f != nil && !f(msg) {
-      return
-    }
-    if h == nil {
       return
     }
     h(msg)

--- a/internal/mux/bridge.go
+++ b/internal/mux/bridge.go
@@ -1,0 +1,32 @@
+package mux
+
+import "github.com/einouqo/castix/internal/bridge"
+
+type Input[T any] struct{ mux[T] }
+
+var (
+  _ bridge.Input[struct{}] = (*Input[struct{}])(nil)
+)
+
+func (in *Input[T]) init() *Input[T] {
+  in.mux.init()
+  return in
+}
+
+func NewInput[T any]() *Input[T] {
+  return new(Input[T]).init()
+}
+
+func (in *Input[T]) Attach(ch <-chan T, options ...bridge.InputAttachOption) bridge.Leave {
+  h := handle[T](func(T) {})
+  for _, option := range options {
+    switch opt := option.(type) {
+    case bridge.AttachHandleOption[T]:
+      h = handle[T](opt)
+    case bridge.AttachFilterOption[T]:
+      // TODO: implement me
+      panic("implement me")
+    }
+  }
+  return in.attach(ch, h)
+}

--- a/internal/mux/mux.go
+++ b/internal/mux/mux.go
@@ -1,0 +1,123 @@
+package mux
+
+import (
+	"reflect"
+	"sync"
+)
+
+type index = int
+
+const (
+	refresh index = iota
+)
+
+var indices = map[index]struct{}{
+	refresh: {},
+}
+
+type handle[T any] func(T)
+
+type mux[T any] struct {
+	wakeup, refresh chan struct{}
+
+	mu  sync.RWMutex
+	ins map[<-chan T]handle[T]
+}
+
+func (x *mux[T]) init() *mux[T] {
+	x.wakeup = make(chan struct{}, 1)
+	x.refresh = make(chan struct{})
+
+	x.ins = make(map[<-chan T]handle[T])
+
+	return x
+}
+
+func (x *mux[T]) attach(ch <-chan T, h handle[T]) (detach func()) {
+	defer x.start()
+
+	x.mu.Lock()
+	x.ins[ch] = h
+	x.mu.Unlock()
+
+	return func() {
+		defer x.start()
+
+		x.mu.Lock()
+		delete(x.ins, ch)
+		x.mu.Unlock()
+	}
+}
+
+func (x *mux[T]) len() int {
+	x.mu.RLock()
+	defer x.mu.RUnlock()
+	return len(x.ins)
+}
+
+func (x *mux[T]) start() {
+	select {
+	case x.refresh <- struct{}{}:
+	case x.wakeup <- struct{}{}:
+		go func() {
+			defer func() { <-x.wakeup }()
+			x.loop()
+		}()
+	}
+}
+
+func (x *mux[T]) loop() {
+	cases := []reflect.SelectCase{
+		refresh: {
+			Dir:  reflect.SelectRecv,
+			Chan: reflect.ValueOf(x.refresh),
+		},
+	}
+
+REFRESH:
+	for i := len(indices); i < len(cases); i++ {
+		// prevent a potential memory leak: internal array may keep a pointer
+		// to a channel that is no longer in use by the program
+		cases[i] = reflect.SelectCase{}
+	}
+	cases = cases[:len(indices)]
+	x.mu.RLock()
+	for ch := range x.ins {
+		cases = append(cases, reflect.SelectCase{
+			Dir:  reflect.SelectRecv,
+			Chan: reflect.ValueOf(ch),
+		})
+	}
+	x.mu.RUnlock()
+
+	for {
+		if len(cases) <= len(indices) {
+			return
+		}
+
+		i, rv, ok := reflect.Select(cases)
+		switch i {
+		case refresh:
+			goto REFRESH
+		}
+
+		ch := cases[i].Chan.Interface().(<-chan T)
+
+		switch {
+		case !ok: // the channel is closed
+			l := len(cases) - 1
+			cases[i], cases[l] = cases[l], reflect.SelectCase{}
+			cases = cases[:l]
+			x.mu.Lock()
+			delete(x.ins, ch)
+			x.mu.Unlock()
+		default:
+			x.mu.RLock()
+			h, hit := x.ins[ch]
+			x.mu.RUnlock()
+			if hit {
+				h(rv.Interface().(T))
+			}
+		}
+	}
+}

--- a/internal/mux/mux_test.go
+++ b/internal/mux/mux_test.go
@@ -1,0 +1,53 @@
+package mux
+
+import (
+	"testing"
+)
+
+func TestMux(t *testing.T) {
+	t.Run("attach", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			count int
+		}{
+			{name: "no one", count: 0},
+			{name: "one", count: 1},
+			{name: "few", count: 1 << 2},
+			{name: "more", count: 1 << 4},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				mux := new(mux[struct{}]).init()
+
+				dets := make([]func(), 0, test.count)
+				for i := 0; i < test.count; i++ {
+					ch := make(chan struct{})
+					t.Cleanup(func() { close(ch) })
+
+					det := mux.attach(ch, func(struct{}) {})
+					dets = append(dets, det)
+				}
+
+				if mux.len() != test.count {
+					t.Errorf(
+						"at least one channel was not attached (want: %d, got: %d)",
+						test.count, len(mux.ins),
+					)
+				}
+
+				for _, det := range dets {
+					det()
+				}
+
+				if mux.len() != 0 {
+					t.Errorf("some were not detached (got: %d)", len(mux.ins))
+				}
+			})
+		}
+	})
+
+	t.Run("handle", func(t *testing.T) {
+		t.Skip("implement me")
+	})
+}

--- a/internal/mux/mux_test.go
+++ b/internal/mux/mux_test.go
@@ -1,7 +1,9 @@
 package mux
 
 import (
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestMux(t *testing.T) {
@@ -18,21 +20,21 @@ func TestMux(t *testing.T) {
 
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				mux := new(mux[struct{}]).init()
+				x := new(mux[struct{}]).init()
 
 				dets := make([]func(), 0, test.count)
 				for i := 0; i < test.count; i++ {
 					ch := make(chan struct{})
 					t.Cleanup(func() { close(ch) })
 
-					det := mux.attach(ch, func(struct{}) {})
+					det := x.attach(ch, func(struct{}) {})
 					dets = append(dets, det)
 				}
 
-				if mux.len() != test.count {
+				if l := x.len(); l != test.count {
 					t.Errorf(
 						"at least one channel was not attached (want: %d, got: %d)",
-						test.count, len(mux.ins),
+						test.count, l,
 					)
 				}
 
@@ -40,14 +42,120 @@ func TestMux(t *testing.T) {
 					det()
 				}
 
-				if mux.len() != 0 {
-					t.Errorf("some were not detached (got: %d)", len(mux.ins))
+				if l := x.len(); l != 0 {
+					t.Errorf("some were not detached (got: %d)", l)
 				}
 			})
 		}
 	})
 
 	t.Run("handle", func(t *testing.T) {
-		t.Skip("implement me")
+		tests := []struct {
+			name   string
+			ins    [][]int
+			expect map[int]int
+		}{
+			{name: "no source", ins: [][]int{}, expect: make(map[int]int)},
+			{
+				name:   "one source unique",
+				ins:    [][]int{{1, 2, 3}},
+				expect: map[int]int{1: 1, 2: 1, 3: 1},
+			},
+			{
+				name:   "one source repeat",
+				ins:    [][]int{{1, 3, 3}},
+				expect: map[int]int{1: 1, 3: 2},
+			},
+			{
+				name:   "few unique sources",
+				ins:    [][]int{{10, 20}, {30, 40}, {50}},
+				expect: map[int]int{10: 1, 20: 1, 30: 1, 40: 1, 50: 1},
+			},
+			{
+				name:   "few sources repeat across",
+				ins:    [][]int{{10, 20}, {20, 30}, {10, 30, 40}},
+				expect: map[int]int{10: 2, 20: 2, 30: 2, 40: 1},
+			},
+			{
+				name:   "few sources repeat internal",
+				ins:    [][]int{{10, 10, 20}, {30, 40, 40}, {50}},
+				expect: map[int]int{10: 2, 20: 1, 30: 1, 40: 2, 50: 1},
+			},
+			{
+				name:   "few sources mixed repeat",
+				ins:    [][]int{{10, 10, 20}, {20, 30, 30}, {10, 40}},
+				expect: map[int]int{10: 3, 20: 2, 30: 2, 40: 1},
+			},
+			{
+				name:   "few sources with empty",
+				ins:    [][]int{{10, 20}, {}, {30, 30}, {40}},
+				expect: map[int]int{10: 1, 20: 1, 30: 2, 40: 1},
+			},
+			{
+				name:   "single empty source",
+				ins:    [][]int{{}},
+				expect: make(map[int]int),
+			},
+			{
+				name:   "all empty sources",
+				ins:    [][]int{{}, {}, {}},
+				expect: make(map[int]int),
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				x := new(mux[int]).init()
+
+				total, rmp := 0, make(map[int]int, len(test.expect))
+				for k, v := range test.expect {
+					total += v
+					rmp[k] = v
+				}
+
+				mu := sync.Mutex{}
+				calls := 0
+				h := func(s int) {
+					mu.Lock()
+					defer mu.Unlock()
+					rmp[s]--
+					calls++
+				}
+
+				wg := sync.WaitGroup{}
+				for _, in := range test.ins {
+					wg.Add(1)
+					go func(in []int) {
+						defer wg.Done()
+
+						ch := make(chan int)
+						defer close(ch)
+
+						x.attach(ch, h)
+
+						for _, s := range in {
+							ch <- s
+						}
+					}(in)
+				}
+				wg.Wait()
+
+				for x.len() != 0 {
+					time.Sleep(time.Millisecond)
+				}
+
+				if calls != total {
+					t.Errorf("less handle calls than expected (want: %d, got: %d)", total, calls)
+				}
+				for v, c := range rmp {
+					if _, hit := test.expect[v]; !hit {
+						t.Errorf("handled unexpected message (value: %d)", v)
+					}
+					if c != 0 {
+						t.Errorf("wrong c of value handle (value: %d, count: %d)", v, c)
+					}
+				}
+			})
+		}
 	})
 }

--- a/option.go
+++ b/option.go
@@ -1,21 +1,25 @@
 package castix
 
-type Option interface {
-	apply(*control)
+import "github.com/einouqo/castix/internal/bridge"
+
+type Filter[T any] func(T) bool
+
+var _ = bridge.Filter[struct{}](Filter[struct{}](nil))
+
+type SourceOption = bridge.AttachOption
+
+func WithSourceFilter[T any](f Filter[T]) bridge.AttachFilterOption[T] {
+	return bridge.WithAttachFilter[T](bridge.Filter[T](f))
 }
 
-func WithDrain() Option {
-	return funcOption{
-		fn: func(ctr *control) { ctr.drain = true },
-	}
-}
+type SubscribeOption = bridge.WatchOption
 
-type funcOption struct {
-	fn func(*control)
-}
+var (
+	WithSubscribeBufferSize = bridge.WithWatchBuffSize
+	WithSubscribeDrain      = bridge.WithWatchDrain
+	WithSubscribeSkip       = bridge.WithWatchSkip
+)
 
-var _ Option = (*funcOption)(nil)
-
-func (f funcOption) apply(ctr *control) {
-	f.fn(ctr)
+func WithSubscribeFilter[T any](f Filter[T]) bridge.WatchFilterOption[T] {
+	return bridge.WithWatchFilter[T](bridge.Filter[T](f))
 }


### PR DESCRIPTION
This pull request introduces a significant refactor and enhancement of the `castix` library, focusing on modularization, extensibility, and improved testing. The changes include replacing the original implementation of `Castix` with a bridge-based architecture, introducing new internal packages (`bridge`, `emit`, `mux`) to handle input/output operations, and adding comprehensive test coverage and benchmarks.

### Refactor and Modularization

* **Bridge-based Architecture**: The `Castix` type now relies on the `bridge` package for handling input/output streams, replacing the previous implementation with a more extensible and modular design. The `bridge` package introduces core abstractions like `Input`, `Output`, `Convert`, and `Leave` to decouple input/output handling (`castix.go`, `internal/bridge/bridge.go`, `internal/bridge/input.go`, `internal/bridge/output.go`, `internal/bridge/type.go`). [[1]](diffhunk://#diff-eae85305329c12730b17cf54935005bbfef7dacb95354a39370bb4120352da6bL3-R39) [[2]](diffhunk://#diff-566bf83babfbf52cfd1f2ca7d4378a196490cd6131fc2d5d62cb5dbb0235ccf8R1-R34) [[3]](diffhunk://#diff-d3435deaef4a3d8daa3771bf457cba4f3cce0e32c52b78a44d5e6f89096c7141R1-R21) [[4]](diffhunk://#diff-4ebe9b475075d927039955167e3ba4fcf3b4e3847e1927632b6ac50be10b961eR1-R48) [[5]](diffhunk://#diff-9cc44b6c974a8d5afa618cf9f2411fa0fe0562488d8f7ac871c1702606163335R1-R9)

* **Emit and Mux Packages**: The `emit` package handles output emission with configurable strategies (e.g., skipping, draining) and filtering, while the `mux` package provides input multiplexing capabilities. These abstractions simplify message passing and allow for dynamic configuration (`internal/emit/bridge.go`, `internal/emit/build.go`, `internal/emit/delivery.go`, `internal/mux/bridge.go`). [[1]](diffhunk://#diff-c98308439ee8244bbce6fb6fa6fc0119232f5d6c891b50414b03448fbb2c0a04R1-R37) [[2]](diffhunk://#diff-4d598189d732dc7302772280e7af1612331eb0890832adb730415ed61e6d5dd0R1-R59) [[3]](diffhunk://#diff-1acba367c4d72d895e38b00cf47b936b0b3666e5d91af2254f223dc76b45380bR1-R40) [[4]](diffhunk://#diff-5d263315aadaa209762ba7db9d2e65a54ab5a4feaabceabfe4140bf57be9c021R1-R35)

### Testing and Benchmarks

* **Enhanced Test Coverage**: Added unit tests for the `emitter` and `bridge` components, covering various scenarios such as message emission, filtering, and strategy-based delivery. These tests ensure the correctness of the modularized implementation (`internal/emit/emitter_test.go`).

* **Benchmarking**: Introduced benchmarks to evaluate the performance of `Castix` under different configurations, including varying numbers of inputs and outputs. This helps assess the scalability of the new architecture (`castix_test.go`).

### Other Improvements

* **Filter and Options**: Added support for filtering messages and configuring input/output behavior through options, such as buffer sizes and delivery strategies (`internal/bridge/option.go`, `internal/emit/option.go`). [[1]](diffhunk://#diff-65b66036d6b56b4ff10bdd41261fc6574965cf42c5f510036064bdd0bb14881cR1-R22) [[2]](diffhunk://#diff-7c308d054fcf5563ec97aa032bfe4fc46f6d80af0b3cb0800693e83af9afa185R1-R37)

* **Test Workflow Update**: Updated the GitHub Actions test workflow to run all tests in the project recursively (`.github/workflows/test.yaml`).