### PR TITLE
chore: add readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Castix
+
+![Go Version](https://img.shields.io/badge/go-1.18+-blue.svg)
+[![Go Report Card](https://goreportcard.com/badge/github.com/einouqo/castix)](https://goreportcard.com/report/github.com/einouqo/castix)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/castix.go
+++ b/castix.go
@@ -1,7 +1,7 @@
 package castix
 
 import (
-  "github.com/einouqo/castix/internal/bridge"
+	"github.com/einouqo/castix/internal/bridge"
 	"github.com/einouqo/castix/internal/emit"
 	"github.com/einouqo/castix/internal/mux"
 )

--- a/internal/bridge/input.go
+++ b/internal/bridge/input.go
@@ -1,21 +1,21 @@
 package bridge
 
 type Input[T any] interface {
-  Attach(<-chan T, Handle[T], ...InputAttachOption) Leave
+	Attach(<-chan T, Handle[T], ...InputAttachOption) Leave
 }
 type AttachFilterOption[T any] Filter[T]
 
 func WithAttachFilter[T any](f Filter[T]) AttachFilterOption[T] {
-  return AttachFilterOption[T](f)
+	return AttachFilterOption[T](f)
 }
 
 func (AttachFilterOption[T]) itsInputAttachOption() {}
 func (AttachFilterOption[T]) itsAttachOption()      {}
 
 type InputAttachOption interface {
-  itsInputAttachOption()
+	itsInputAttachOption()
 }
 
 var (
-  _ InputAttachOption = (*AttachFilterOption[struct{}])(nil)
+	_ InputAttachOption = (*AttachFilterOption[struct{}])(nil)
 )

--- a/internal/bridge/output.go
+++ b/internal/bridge/output.go
@@ -1,8 +1,8 @@
 package bridge
 
 type Output[T any] interface {
-  Pass(T)
-  Watch(...OutputWatchOption) (<-chan T, Leave)
+	Pass(T)
+	Watch(...OutputWatchOption) (<-chan T, Leave)
 }
 
 type WatchBufferSizeOption int
@@ -11,7 +11,7 @@ func (WatchBufferSizeOption) itsOutputWatchOption() {}
 func (WatchBufferSizeOption) itsWatchOption()       {}
 
 func WithWatchBuffSize(size int) WatchBufferSizeOption {
-  return WatchBufferSizeOption(size)
+	return WatchBufferSizeOption(size)
 }
 
 type WatchDrainOption struct{}
@@ -34,15 +34,15 @@ func (WatchFilterOption[T]) itsOutputWatchOption() {}
 func (WatchFilterOption[T]) itsWatchOption()       {}
 
 func WithWatchFilter[T any](f Filter[T]) WatchFilterOption[T] {
-  return WatchFilterOption[T](f)
+	return WatchFilterOption[T](f)
 }
 
 type OutputWatchOption interface {
-  itsOutputWatchOption()
+	itsOutputWatchOption()
 }
 
 var (
-  _ OutputWatchOption = (*WatchBufferSizeOption)(nil)
-  _ OutputWatchOption = (*WatchDrainOption)(nil)
-  _ OutputWatchOption = (*WatchSkipOption)(nil)
+	_ OutputWatchOption = (*WatchBufferSizeOption)(nil)
+	_ OutputWatchOption = (*WatchDrainOption)(nil)
+	_ OutputWatchOption = (*WatchSkipOption)(nil)
 )

--- a/internal/emit/bridge.go
+++ b/internal/emit/bridge.go
@@ -5,33 +5,33 @@ import "github.com/einouqo/castix/internal/bridge"
 type Output[T any] struct{ emitter[T] }
 
 var (
-  _ bridge.Output[struct{}] = (*Output[struct{}])(nil)
+	_ bridge.Output[struct{}] = (*Output[struct{}])(nil)
 )
 
 func (o *Output[T]) init() *Output[T] {
-  o.emitter.init()
-  return o
+	o.emitter.init()
+	return o
 }
 
 func NewOutput[T any]() *Output[T] {
-  return new(Output[T]).init()
+	return new(Output[T]).init()
 }
 
 func (o *Output[T]) Pass(msg T) { o.emit(msg) }
 
 func (o *Output[T]) Watch(options ...bridge.OutputWatchOption) (<-chan T, bridge.Leave) {
-  opts := make([]option, 0, len(options))
-  for _, opt := range options {
-    switch opt := opt.(type) {
-    case bridge.WatchBufferSizeOption:
-      opts = append(opts, withBuffSize(int(opt)))
-    case bridge.WatchSkipOption:
-      opts = append(opts, withStrategy(skipping))
-    case bridge.WatchDrainOption:
-      opts = append(opts, withStrategy(draining))
-    case bridge.WatchFilterOption[T]:
-      opts = append(opts, withFilter[T](filter[T](opt)))
-    }
-  }
-  return o.watch(opts...)
+	opts := make([]option, 0, len(options))
+	for _, opt := range options {
+		switch opt := opt.(type) {
+		case bridge.WatchBufferSizeOption:
+			opts = append(opts, withBuffSize(int(opt)))
+		case bridge.WatchSkipOption:
+			opts = append(opts, withStrategy(skipping))
+		case bridge.WatchDrainOption:
+			opts = append(opts, withStrategy(draining))
+		case bridge.WatchFilterOption[T]:
+			opts = append(opts, withFilter[T](filter[T](opt)))
+		}
+	}
+	return o.watch(opts...)
 }

--- a/internal/emit/build.go
+++ b/internal/emit/build.go
@@ -9,8 +9,8 @@ const (
 )
 
 type config struct {
-  size  int
-  strat strategy
+  size     int
+  strategy strategy
 }
 
 func (c *config) init() *config {
@@ -43,7 +43,7 @@ func build[T any](done <-chan struct{}, opts ...option) (chan T, deliver[T]) {
 
   ch, dlv := make(chan T, s.size), send[T](done)
 
-  switch s.strat {
+  switch s.strategy {
   case draining:
     dlv = drain[T](done)
   case skipping:

--- a/internal/emit/emitter.go
+++ b/internal/emit/emitter.go
@@ -1,55 +1,55 @@
 package emit
 
 import (
-  "sync"
-  "sync/atomic"
+	"sync"
+	"sync/atomic"
 )
 
 var cil = (chan struct{})(nil)
 
 type emitter[T any] struct {
-  mu   sync.RWMutex
-  outs map[chan T]deliver[T]
+	mu   sync.RWMutex
+	outs map[chan T]deliver[T]
 }
 
 func (e *emitter[T]) init() *emitter[T] {
-  e.outs = make(map[chan T]deliver[T])
-  return e
+	e.outs = make(map[chan T]deliver[T])
+	return e
 }
 
 func (e *emitter[T]) emit(msg T) {
-  e.mu.RLock()
-  defer e.mu.RUnlock()
-  for out, dlv := range e.outs {
-    dlv(out, msg)
-  }
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	for out, dlv := range e.outs {
+		dlv(out, msg)
+	}
 }
 
 func (e *emitter[T]) watch(opts ...option) (c <-chan T, stop func()) {
-  done := atomic.Value{}
-  done.Store(make(chan struct{}))
+	done := atomic.Value{}
+	done.Store(make(chan struct{}))
 
-  ch, dlv := build[T](
-    done.Load().(chan struct{}),
-    opts...,
-  )
+	ch, dlv := build[T](
+		done.Load().(chan struct{}),
+		opts...,
+	)
 
-  e.mu.Lock()
-  e.outs[ch] = dlv
-  e.mu.Unlock()
+	e.mu.Lock()
+	e.outs[ch] = dlv
+	e.mu.Unlock()
 
-  return ch, func() {
-    d := done.Swap(cil).(chan struct{})
-    if d == cil {
-      return // already stopped
-    }
-    close(d)
+	return ch, func() {
+		d := done.Swap(cil).(chan struct{})
+		if d == cil {
+			return // already stopped
+		}
+		close(d)
 
-    e.mu.Lock()
-    defer e.mu.Unlock()
-    if _, hit := e.outs[ch]; hit {
-      close(ch)
-      delete(e.outs, ch)
-    }
-  }
+		e.mu.Lock()
+		defer e.mu.Unlock()
+		if _, hit := e.outs[ch]; hit {
+			close(ch)
+			delete(e.outs, ch)
+		}
+	}
 }

--- a/internal/emit/emitter_test.go
+++ b/internal/emit/emitter_test.go
@@ -1,142 +1,142 @@
 package emit
 
 import (
-  "sync"
-  "testing"
+	"sync"
+	"testing"
 )
 
 func TestEmitter(t *testing.T) {
-  t.Run("emit", func(t *testing.T) {
-    e := new(emitter[byte]).init()
+	t.Run("emit", func(t *testing.T) {
+		e := new(emitter[byte]).init()
 
-    msgs := []byte{1, 2, 3}
+		msgs := []byte{1, 2, 3}
 
-    tests := []struct {
-      name  string
-      count int
-    }{
-      {name: "no one", count: 0},
-      {name: "one", count: 1},
-      {name: "few", count: 9},
-      {name: "more", count: 10},
-    }
+		tests := []struct {
+			name  string
+			count int
+		}{
+			{name: "no one", count: 0},
+			{name: "one", count: 1},
+			{name: "few", count: 9},
+			{name: "more", count: 10},
+		}
 
-    for _, test := range tests {
-      t.Run(test.name, func(t *testing.T) {
-        chs := make(map[<-chan byte]func())
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				chs := make(map[<-chan byte]func())
 
-        for i := 0; i < test.count; i++ {
-          ch, stop := e.watch()
-          chs[ch] = stop
-        }
+				for i := 0; i < test.count; i++ {
+					ch, stop := e.watch()
+					chs[ch] = stop
+				}
 
-        var wg sync.WaitGroup
+				var wg sync.WaitGroup
 
-        wg.Add(1)
-        go func() {
-          defer wg.Done()
-          for _, msg := range msgs {
-            e.emit(msg)
-          }
-        }()
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					for _, msg := range msgs {
+						e.emit(msg)
+					}
+				}()
 
-        for ch, stop := range chs {
-          wg.Add(1)
-          go func(ch <-chan byte, stop func()) {
-            defer wg.Done()
-            defer stop()
-            for _, msg := range msgs {
-              r, ok := <-ch
-              if !ok {
-                t.Error("channel is closed")
-              }
-              if r != msg {
-                t.Errorf("received wrong message (want: %d, got: %d)", msg, r)
-              }
-            }
-          }(ch, stop)
-        }
+				for ch, stop := range chs {
+					wg.Add(1)
+					go func(ch <-chan byte, stop func()) {
+						defer wg.Done()
+						defer stop()
+						for _, msg := range msgs {
+							r, ok := <-ch
+							if !ok {
+								t.Error("channel is closed")
+							}
+							if r != msg {
+								t.Errorf("received wrong message (want: %d, got: %d)", msg, r)
+							}
+						}
+					}(ch, stop)
+				}
 
-        wg.Wait()
-        if c := len(e.outs); c != 0 {
-          t.Errorf("inspection failed (expect 0 subscribers, got %d)", c)
-        }
-      })
-    }
-  })
+				wg.Wait()
+				if c := len(e.outs); c != 0 {
+					t.Errorf("inspection failed (expect 0 subscribers, got %d)", c)
+				}
+			})
+		}
+	})
 
-  t.Run("strategy", func(t *testing.T) {
-    e := new(emitter[byte]).init()
+	t.Run("strategy", func(t *testing.T) {
+		e := new(emitter[byte]).init()
 
-    msgs := []byte{1, 2, 3}
+		msgs := []byte{1, 2, 3}
 
-    tests := []struct {
-      name     string
-      strategy strategy
-      expect   byte
-    }{
-      {name: "skipping", strategy: skipping, expect: 1},
-      {name: "draining", strategy: draining, expect: 3},
-    }
+		tests := []struct {
+			name     string
+			strategy strategy
+			expect   byte
+		}{
+			{name: "skipping", strategy: skipping, expect: 1},
+			{name: "draining", strategy: draining, expect: 3},
+		}
 
-    for _, test := range tests {
-      t.Run(test.name, func(t *testing.T) {
-        ch, stop := e.watch(withStrategy(test.strategy))
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				ch, stop := e.watch(withStrategy(test.strategy))
 
-        for _, msg := range msgs {
-          e.emit(msg)
-        }
+				for _, msg := range msgs {
+					e.emit(msg)
+				}
 
-        stop()
-        if msg := <-ch; msg != test.expect {
-          t.Errorf("message should be %d but got %d", test.expect, msg)
-        }
-        if _, ok := <-ch; ok {
-          t.Errorf("subscribe channel should be closed after stop and read last")
-        }
-      })
-    }
-  })
+				stop()
+				if msg := <-ch; msg != test.expect {
+					t.Errorf("message should be %d but got %d", test.expect, msg)
+				}
+				if _, ok := <-ch; ok {
+					t.Errorf("subscribe channel should be closed after stop and read last")
+				}
+			})
+		}
+	})
 
-  t.Run("filter", func(t *testing.T) {
-    e := new(emitter[int]).init()
+	t.Run("filter", func(t *testing.T) {
+		e := new(emitter[int]).init()
 
-    msgs := []int{-3, -2, -1, 0, 1, 2, 3}
+		msgs := []int{-3, -2, -1, 0, 1, 2, 3}
 
-    tests := []struct {
-      name   string
-      filter filter[int]
-      expect []int
-    }{
-      {name: "odds", filter: func(k int) bool { return k%2 != 0 }, expect: []int{-3, -1, 1, 3}},
-      {name: "evens", filter: func(k int) bool { return k%2 == 0 }, expect: []int{-2, 0, 2}},
-    }
+		tests := []struct {
+			name   string
+			filter filter[int]
+			expect []int
+		}{
+			{name: "odds", filter: func(k int) bool { return k%2 != 0 }, expect: []int{-3, -1, 1, 3}},
+			{name: "evens", filter: func(k int) bool { return k%2 == 0 }, expect: []int{-2, 0, 2}},
+		}
 
-    for _, test := range tests {
-      t.Run(test.name, func(t *testing.T) {
-        ch, stop := e.watch(withFilter(test.filter))
-        defer stop()
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				ch, stop := e.watch(withFilter(test.filter))
+				defer stop()
 
-        done := make(chan struct{})
-        go func() {
-          defer close(done)
-          for _, msg := range msgs {
-            e.emit(msg)
-          }
-        }()
+				done := make(chan struct{})
+				go func() {
+					defer close(done)
+					for _, msg := range msgs {
+						e.emit(msg)
+					}
+				}()
 
-        for i, msg := range test.expect {
-          r, ok := <-ch
-          if !ok {
-            t.Error("channel is closed")
-          }
-          if r != msg {
-            t.Errorf("received wrong message (iteration: %d, want: %d, got: %d)", i, msg, r)
-          }
-        }
+				for i, msg := range test.expect {
+					r, ok := <-ch
+					if !ok {
+						t.Error("channel is closed")
+					}
+					if r != msg {
+						t.Errorf("received wrong message (iteration: %d, want: %d, got: %d)", i, msg, r)
+					}
+				}
 
-        <-done
-      })
-    }
-  })
+				<-done
+			})
+		}
+	})
 }

--- a/internal/emit/option.go
+++ b/internal/emit/option.go
@@ -3,35 +3,35 @@ package emit
 type configure func(*config)
 
 var (
-  _ option = configure(nil)
+	_ option = configure(nil)
 )
 
 func (configure) itsOption() {}
 
 func withBuffSize(size int) configure {
-  return func(c *config) {
-    if size >= 1 {
-      c.size = size
-    }
-  }
+	return func(c *config) {
+		if size >= 1 {
+			c.size = size
+		}
+	}
 }
 
 func withStrategy(s strategy) configure {
-  return func(c *config) { c.strat = s }
+	return func(c *config) { c.strategy = s }
 }
 
 type setup[T any] func(*settings[T])
 
 var (
-  _ option = setup[struct{}](nil)
+	_ option = setup[struct{}](nil)
 )
 
 func (s setup[T]) itsOption() {}
 
 func withFilter[T any](f filter[T]) setup[T] {
-  return func(s *settings[T]) { s.filter = f }
+	return func(s *settings[T]) { s.filter = f }
 }
 
 type option interface {
-  itsOption()
+	itsOption()
 }

--- a/internal/mux/bridge.go
+++ b/internal/mux/bridge.go
@@ -5,31 +5,31 @@ import "github.com/einouqo/castix/internal/bridge"
 type Input[T any] struct{ mux[T] }
 
 var (
-  _ bridge.Input[struct{}] = (*Input[struct{}])(nil)
+	_ bridge.Input[struct{}] = (*Input[struct{}])(nil)
 )
 
 func (in *Input[T]) init() *Input[T] {
-  in.mux.init()
-  return in
+	in.mux.init()
+	return in
 }
 
 func NewInput[T any]() *Input[T] {
-  return new(Input[T]).init()
+	return new(Input[T]).init()
 }
 
 func (in *Input[T]) Attach(ch <-chan T, h bridge.Handle[T], opts ...bridge.InputAttachOption) bridge.Leave {
-  var f bridge.Filter[T]
-  for _, opt := range opts {
-    switch opt := opt.(type) {
-    case bridge.AttachFilterOption[T]:
-      f = bridge.Filter[T](opt)
-    }
-  }
+	var f bridge.Filter[T]
+	for _, opt := range opts {
+		switch opt := opt.(type) {
+		case bridge.AttachFilterOption[T]:
+			f = bridge.Filter[T](opt)
+		}
+	}
 
-  return in.attach(ch, func(msg T) {
-    if f != nil && !f(msg) {
-      return
-    }
-    h(msg)
-  })
+	return in.attach(ch, func(msg T) {
+		if f != nil && !f(msg) {
+			return
+		}
+		h(msg)
+	})
 }


### PR DESCRIPTION
This pull request introduces a new project, `Castix`, with updates to the documentation and refactors to improve code readability and consistency. The most significant changes include adding a project description and badges to the `README.md` and renaming the `strat` field to `strategy` across multiple files for clarity.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1-R5): Added a project title (`Castix`) and badges for Go version, Go Report Card, and license information.

### Code Refactoring:
* [`internal/emit/build.go`](diffhunk://#diff-4d598189d732dc7302772280e7af1612331eb0890832adb730415ed61e6d5dd0L13-R13): Renamed the `strat` field to `strategy` in the `config` struct and updated all references to this field in the `build` function to improve clarity. [[1]](diffhunk://#diff-4d598189d732dc7302772280e7af1612331eb0890832adb730415ed61e6d5dd0L13-R13) [[2]](diffhunk://#diff-4d598189d732dc7302772280e7af1612331eb0890832adb730415ed61e6d5dd0L46-R46)
* [`internal/emit/option.go`](diffhunk://#diff-7c308d054fcf5563ec97aa032bfe4fc46f6d80af0b3cb0800693e83af9afa185L20-R20): Updated the `withStrategy` function to use the renamed `strategy` field, ensuring consistency across the codebase.