### PR TITLE
feat: add go doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Castix
 
 ![Go Version](https://img.shields.io/badge/go-1.18+-blue.svg)
+[![Go Reference](https://pkg.go.dev/badge/github.com/einouqo/castix.svg)](https://pkg.go.dev/github.com/einouqo/castix)
 [![Go Report Card](https://goreportcard.com/badge/github.com/einouqo/castix)](https://goreportcard.com/report/github.com/einouqo/castix)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+**Castix** provides a flexible way to manage message streams in your applications. It acts as a central hub (multiplexer) where multiple message producers (sources) can send messages, and multiple consumers (subscribers) can receive them.

--- a/castix.go
+++ b/castix.go
@@ -6,22 +6,35 @@ import (
 	"github.com/einouqo/castix/internal/mux"
 )
 
+// Leave is a function that should be called to clean up resources
 type Leave = bridge.Leave
 
+// Convert defines a function signature for converting a value of type IN
+// to a value of type OUT. This is used by Castix to transform messages
+// from their source type to the desired output type for subscribers.
 type Convert[IN, OUT any] func(IN) OUT
 
 var _ = bridge.Convert[struct{}, struct{}](Convert[struct{}, struct{}](nil))
 
+// Pass is a utility Convert function that returns the input value unchanged.
+// It can be used when no type conversion is necessary between the source and subscriber (i.e., IN and OUT are the same type).
 func Pass[T any](in T) T { return in }
 
-var (
-	_ Convert[struct{}, struct{}] = Pass[struct{}]
-)
+var _ Convert[struct{}, struct{}] = Pass[struct{}]
 
+// Castix provides a flexible and type-safe way to manage message streams.
+// It acts as a multiplexer, allowing multiple message producers (sources)
+// to broadcast messages to multiple consumers (subscribers).
+// Castix also handles type conversion between the source message type (IN)
+// and the subscriber's desired message type (OUT) using a provided Convert function.
 type Castix[IN, OUT any] struct {
 	bridge *bridge.Bridge[IN, OUT]
 }
 
+// New creates and initializes a new Castix instance.
+// It requires a Convert function `cv` that defines how messages of type IN
+// are transformed into messages of type OUT. If no transformation is needed
+// (IN and OUT are the same type), the Pass function can be used.
 func New[IN, OUT any](cv Convert[IN, OUT]) *Castix[IN, OUT] {
 	return &Castix[IN, OUT]{
 		bridge: bridge.New[IN, OUT](
@@ -31,10 +44,41 @@ func New[IN, OUT any](cv Convert[IN, OUT]) *Castix[IN, OUT] {
 	}
 }
 
+// Source attaches a Go channel `ch` as a message producer to the Castix instance.
+// Messages sent to `ch` will be processed by Castix, converted according to the
+// function provided to New, and then distributed to all active subscribers.
+//
+// Callers can provide SourceOption arguments to customize the behavior of the source.
+// Available options include:
+//   - WithSourceFilter: Applies a filter to messages before they are sent to the subscribers.
+//
+// It returns a Leave function. This function MUST be called when the source channel
+// is no longer needed. Calling Leave detaches the source from Castix and releases
+// associated resources. The source will also be detached automatically if the provided
+// `ch` channel is closed. In both scenarios, resources are cleaned up.
 func (x Castix[IN, OUT]) Source(ch <-chan IN, opts ...SourceOption) Leave {
 	return x.bridge.Attach(ch, opts...)
 }
 
+// Subscribe creates a new subscription to receive messages processed by the Castix instance.
+// It returns two values:
+//  1. A receive-only channel on which converted messages of type OUT
+//     will be delivered.
+//  2. A Leave function.
+//
+// Messages sent to this channel originate from all attached sources and are converted
+// using the Convert function specified when the Castix instance was created.
+//
+// Callers can provide `SubscribeOption` arguments to customize the subscription's
+// behavior. Available options include:
+//   - WithSubscribeBufferSize: Configures the buffer size of the returned message channel.
+//   - WithSubscribeFilter: Applies a filter to messages before they are sent to the channel.
+//   - WithSubscribeDrain: Ensures all buffered messages are processed when unsubscribing.
+//   - WithSubscribeSkip: Allows dropping messages if the subscription channel's buffer is full.
+//
+// The returned Leave function MUST be called when the subscription is no longer
+// needed. This will close the message channel and release all associated resources.
+// It's important to call Leave to prevent indefinite goroutine blocking and resource leaks.
 func (x Castix[IN, OUT]) Subscribe(opts ...SubscribeOption) (<-chan OUT, Leave) {
 	return x.bridge.Watch(opts...)
 }

--- a/internal/bridge/input.go
+++ b/internal/bridge/input.go
@@ -16,6 +16,4 @@ type InputAttachOption interface {
 	itsInputAttachOption()
 }
 
-var (
-	_ InputAttachOption = (*AttachFilterOption[struct{}])(nil)
-)
+var _ InputAttachOption = (*AttachFilterOption[struct{}])(nil)

--- a/internal/bridge/option.go
+++ b/internal/bridge/option.go
@@ -5,9 +5,7 @@ type AttachOption interface {
 	itsAttachOption()
 }
 
-var (
-	_ AttachOption = (*AttachFilterOption[struct{}])(nil)
-)
+var _ AttachOption = (*AttachFilterOption[struct{}])(nil)
 
 type WatchOption interface {
 	OutputWatchOption

--- a/internal/emit/bridge.go
+++ b/internal/emit/bridge.go
@@ -4,9 +4,7 @@ import "github.com/einouqo/castix/internal/bridge"
 
 type Output[T any] struct{ emitter[T] }
 
-var (
-	_ bridge.Output[struct{}] = (*Output[struct{}])(nil)
-)
+var _ bridge.Output[struct{}] = (*Output[struct{}])(nil)
 
 func (o *Output[T]) init() *Output[T] {
 	o.emitter.init()

--- a/internal/emit/build.go
+++ b/internal/emit/build.go
@@ -3,57 +3,57 @@ package emit
 type strategy uint8
 
 const (
-  _ strategy = iota
-  draining
-  skipping
+	_ strategy = iota
+	draining
+	skipping
 )
 
 type config struct {
-  size     int
-  strategy strategy
+	size     int
+	strategy strategy
 }
 
 func (c *config) init() *config {
-  c.size = 1
-  return c
+	c.size = 1
+	return c
 }
 
 type filter[T any] func(T) bool
 
 type settings[T any] struct {
-  config
-  filter[T]
+	config
+	filter[T]
 }
 
 func (s *settings[T]) init() *settings[T] {
-  s.config.init()
-  return s
+	s.config.init()
+	return s
 }
 
 func build[T any](done <-chan struct{}, opts ...option) (chan T, deliver[T]) {
-  s := new(settings[T]).init()
-  for _, opt := range opts {
-    switch opt := opt.(type) {
-    case configure:
-      opt(&s.config)
-    case setup[T]:
-      opt(s)
-    }
-  }
+	s := new(settings[T]).init()
+	for _, opt := range opts {
+		switch opt := opt.(type) {
+		case configure:
+			opt(&s.config)
+		case setup[T]:
+			opt(s)
+		}
+	}
 
-  ch, dlv := make(chan T, s.size), send[T](done)
+	ch, dlv := make(chan T, s.size), send[T](done)
 
-  switch s.strategy {
-  case draining:
-    dlv = drain[T](done)
-  case skipping:
-    dlv = skip[T](done)
-  }
+	switch s.strategy {
+	case draining:
+		dlv = drain[T](done)
+	case skipping:
+		dlv = skip[T](done)
+	}
 
-  return ch, func(ch chan T, msg T) {
-    if s.filter != nil && !s.filter(msg) {
-      return
-    }
-    dlv(ch, msg)
-  }
+	return ch, func(ch chan T, msg T) {
+		if s.filter != nil && !s.filter(msg) {
+			return
+		}
+		dlv(ch, msg)
+	}
 }

--- a/internal/emit/option.go
+++ b/internal/emit/option.go
@@ -2,9 +2,7 @@ package emit
 
 type configure func(*config)
 
-var (
-	_ option = configure(nil)
-)
+var _ option = configure(nil)
 
 func (configure) itsOption() {}
 
@@ -22,9 +20,7 @@ func withStrategy(s strategy) configure {
 
 type setup[T any] func(*settings[T])
 
-var (
-	_ option = setup[struct{}](nil)
-)
+var _ option = setup[struct{}](nil)
 
 func (s setup[T]) itsOption() {}
 

--- a/internal/mux/bridge.go
+++ b/internal/mux/bridge.go
@@ -4,9 +4,7 @@ import "github.com/einouqo/castix/internal/bridge"
 
 type Input[T any] struct{ mux[T] }
 
-var (
-	_ bridge.Input[struct{}] = (*Input[struct{}])(nil)
-)
+var _ bridge.Input[struct{}] = (*Input[struct{}])(nil)
 
 func (in *Input[T]) init() *Input[T] {
 	in.mux.init()

--- a/option.go
+++ b/option.go
@@ -2,24 +2,55 @@ package castix
 
 import "github.com/einouqo/castix/internal/bridge"
 
+// Filter defines a function signature for a predicate that determines
+// whether a message of type T should be processed or discarded/skipped.
+// Must return true if a trial is passed and false otherwise
 type Filter[T any] func(T) bool
 
 var _ = bridge.Filter[struct{}](Filter[struct{}](nil))
 
+// SourceOption represents an option that can be applied when attaching a source
+// to a Castix instance via the Source method.
 type SourceOption = bridge.AttachOption
 
+// WithSourceFilter returns a SourceOption that applies a filter to messages
+// coming from a specific source. Only messages for which the filter function `f`
+// returns true will be passed on for conversion and distribution.
+// The filter is applied before type conversion.
 func WithSourceFilter[T any](f Filter[T]) bridge.AttachFilterOption[T] {
 	return bridge.WithAttachFilter[T](bridge.Filter[T](f))
 }
 
+// SubscribeOption represents an option that can be applied when creating a subscription
+// to a Castix instance via the Subscribe method.
 type SubscribeOption = bridge.WatchOption
 
 var (
+	// WithSubscribeBufferSize returns a SubscribeOption that configures the buffer
+	// size of the channel returned by the Subscribe method.
+	// A larger buffer can help prevent blocking (when using default delivery strategy)
+	// if the subscriber processes messages slower than they are produced but consumes
+	// more memory.
 	WithSubscribeBufferSize = bridge.WithWatchBuffSize
-	WithSubscribeDrain      = bridge.WithWatchDrain
-	WithSubscribeSkip       = bridge.WithWatchSkip
+
+	// WithSubscribeDrain returns a SubscribeOption that causes the subscription to
+	// drop older messages in its buffer when it is full, removing the oldest message
+	// to make room for the newest one. This strategy prioritizes newer messages at the
+	// expense of potentially losing older ones when the subscriber cannot keep up with
+	// the message rate.
+	WithSubscribeDrain = bridge.WithWatchDrain
+
+	// WithSubscribeSkip returns a SubscribeOption that causes the subscription to
+	// drop messages if its buffer is full, instead of blocking the Castix multiplexer.
+	// This can be useful when timely processing is less critical than overall system
+	// responsiveness, but may lead to message loss.
+	WithSubscribeSkip = bridge.WithWatchSkip
 )
 
+// WithSubscribeFilter returns a SubscribeOption that applies a filter to messages
+// designated for a specific subscription. Only messages for which the filter function `f`
+// returns true will be sent to the subscription's channel.
+// The filter is applied before sending a message to the subscribed channel.
 func WithSubscribeFilter[T any](f Filter[T]) bridge.WatchFilterOption[T] {
 	return bridge.WithWatchFilter[T](bridge.Filter[T](f))
 }


### PR DESCRIPTION
This pull request introduces several enhancements and improvements to the `Castix` library, focusing on documentation, type safety, and functionality for managing message streams. Key changes include adding detailed comments and documentation for public APIs, introducing new options for filtering and managing message flow, and improving code readability by removing redundant type assertions.

### Enhancements to documentation and public APIs:
* Added detailed comments to `Castix` methods (`Source`, `Subscribe`, and `New`) explaining their functionality, expected usage, and the importance of calling `Leave` to release resources. (`[castix.goR47-R81](diffhunk://#diff-eae85305329c12730b17cf54935005bbfef7dacb95354a39370bb4120352da6bR47-R81)`)
* Introduced documentation for the `Filter`, `SourceOption`, and `SubscribeOption` types, along with their associated methods (`WithSourceFilter`, `WithSubscribeFilter`, etc.), to clarify their purpose and usage. (`[option.goR5-R53](diffhunk://#diff-086a37ef11c8fd9a2516991339db79c207741ac98dd89c8215d31a8bead2814fR5-R53)`)
* Updated the `README.md` file to include a description of the `Castix` library and its purpose, as well as a badge linking to the Go package reference. (`[README.mdR4-R8](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R4-R8)`)

### New functionality:
* Added utility functions and options for filtering and managing message flow:
  - [`WithSourceFilter`](diffhunk://#diff-086a37ef11c8fd9a2516991339db79c207741ac98dd89c8215d31a8bead2814fR5-R53): Filters messages from sources before conversion and distribution. (`[option.goR5-R53](diffhunk://#diff-086a37ef11c8fd9a2516991339db79c207741ac98dd89c8215d31a8bead2814fR5-R53)`)
  - [`WithSubscribeFilter`](diffhunk://#diff-086a37ef11c8fd9a2516991339db79c207741ac98dd89c8215d31a8bead2814fR5-R53): Filters messages for specific subscriptions before delivery. (`[option.goR5-R53](diffhunk://#diff-086a37ef11c8fd9a2516991339db79c207741ac98dd89c8215d31a8bead2814fR5-R53)`)
  - `WithSubscribeBufferSize`, `WithSubscribeDrain`, and `WithSubscribeSkip`: Options for managing subscription channel behavior, such as buffer size and message loss strategies. (`[option.goR5-R53](diffhunk://#diff-086a37ef11c8fd9a2516991339db79c207741ac98dd89c8215d31a8bead2814fR5-R53)`)

### Code cleanup and type safety:
* Removed redundant type assertions throughout the codebase, simplifying the implementation while maintaining type safety:
  - `internal/bridge/input.go` (`[internal/bridge/input.goL19-R19](diffhunk://#diff-d3435deaef4a3d8daa3771bf457cba4f3cce0e32c52b78a44d5e6f89096c7141L19-R19)`)
  - `internal/bridge/option.go` (`[internal/bridge/option.goL8-R8](diffhunk://#diff-65b66036d6b56b4ff10bdd41261fc6574965cf42c5f510036064bdd0bb14881cL8-R8)`)
  - `internal/emit/bridge.go` (`[internal/emit/bridge.goL7-R7](diffhunk://#diff-c98308439ee8244bbce6fb6fa6fc0119232f5d6c891b50414b03448fbb2c0a04L7-R7)`)
  - `internal/emit/option.go` (`[[1]](diffhunk://#diff-7c308d054fcf5563ec97aa032bfe4fc46f6d80af0b3cb0800693e83af9afa185L5-R5)`, `[[2]](diffhunk://#diff-7c308d054fcf5563ec97aa032bfe4fc46f6d80af0b3cb0800693e83af9afa185L25-R23)`)
  - `internal/mux/bridge.go` (`[internal/mux/bridge.goL7-R7](diffhunk://#diff-5d263315aadaa209762ba7db9d2e65a54ab5a4feaabceabfe4140bf57be9c021L7-R7)`)