### PR TITLE
feat: new goroutine mux

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,6 +10,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-      - uses: golangci/golangci-lint-action@v7
+      - uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.0.2
+          version: v2.1.6

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,5 @@
+version: "2"
+
+linters:
+  disable:
+    - unused

--- a/README.md
+++ b/README.md
@@ -5,4 +5,6 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/einouqo/castix)](https://goreportcard.com/report/github.com/einouqo/castix)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-**Castix** provides a flexible way to manage message streams in your applications. It acts as a central hub (multiplexer) where multiple message producers (sources) can send messages, and multiple consumers (subscribers) can receive them.
+**Castix** provides a flexible way to manage message streams in your applications. It acts as a central hub (
+multiplexer) where multiple message producers (sources) can send messages, and multiple consumers (subscribers) can
+receive them.

--- a/castix.go
+++ b/castix.go
@@ -22,7 +22,7 @@ func Pass[T any](in T) T { return in }
 
 var _ Convert[struct{}, struct{}] = Pass[struct{}]
 
-// Castix provides a flexible and type-safe way to manage message streams.
+// Castix provides a flexible way to manage message streams.
 // It acts as a multiplexer, allowing multiple message producers (sources)
 // to broadcast messages to multiple consumers (subscribers).
 // Castix also handles type conversion between the source message type (IN)
@@ -35,10 +35,15 @@ type Castix[IN, OUT any] struct {
 // It requires a Convert function `cv` that defines how messages of type IN
 // are transformed into messages of type OUT. If no transformation is needed
 // (IN and OUT are the same type), the Pass function can be used.
-func New[IN, OUT any](cv Convert[IN, OUT]) *Castix[IN, OUT] {
+func New[IN, OUT any](cv Convert[IN, OUT], opts ...Option) *Castix[IN, OUT] {
+	cfg := new(config).init()
+	for _, opt := range opts {
+		opt.apply(cfg)
+	}
+
 	return &Castix[IN, OUT]{
 		bridge: bridge.New[IN, OUT](
-			mux.NewInput[IN](), emit.NewOutput[OUT](),
+			mux.NewInput[IN](cfg.input...), emit.NewOutput[OUT](),
 			bridge.Convert[IN, OUT](cv),
 		),
 	}

--- a/internal/bridge/type.go
+++ b/internal/bridge/type.go
@@ -1,6 +1,6 @@
 package bridge
 
-type Leave func()
+type Leave = func()
 
 type Convert[IN, OUT any] func(IN) OUT
 

--- a/internal/emit/bridge.go
+++ b/internal/emit/bridge.go
@@ -15,7 +15,7 @@ func NewOutput[T any]() *Output[T] {
 	return new(Output[T]).init()
 }
 
-func (o *Output[T]) Pass(msg T) { o.emit(msg) }
+func (o *Output[T]) Pass(v T) { o.emit(v) }
 
 func (o *Output[T]) Watch(options ...bridge.OutputWatchOption) (<-chan T, bridge.Leave) {
 	opts := make([]option, 0, len(options))
@@ -24,11 +24,11 @@ func (o *Output[T]) Watch(options ...bridge.OutputWatchOption) (<-chan T, bridge
 		case bridge.WatchBufferSizeOption:
 			opts = append(opts, withBuffSize(int(opt)))
 		case bridge.WatchSkipOption:
-			opts = append(opts, withStrategy(skipping))
+			opts = append(opts, use(skipping))
 		case bridge.WatchDrainOption:
-			opts = append(opts, withStrategy(draining))
+			opts = append(opts, use(draining))
 		case bridge.WatchFilterOption[T]:
-			opts = append(opts, withFilter[T](filter[T](opt)))
+			opts = append(opts, filtrate[T](filter[T](opt)))
 		}
 	}
 	return o.watch(opts...)

--- a/internal/emit/build.go
+++ b/internal/emit/build.go
@@ -50,10 +50,10 @@ func build[T any](done <-chan struct{}, opts ...option) (chan T, deliver[T]) {
 		dlv = skip[T](done)
 	}
 
-	return ch, func(ch chan T, msg T) {
-		if s.filter != nil && !s.filter(msg) {
+	return ch, func(ch chan T, v T) {
+		if s.filter != nil && !s.filter(v) {
 			return
 		}
-		dlv(ch, msg)
+		dlv(ch, v)
 	}
 }

--- a/internal/emit/delivery.go
+++ b/internal/emit/delivery.go
@@ -3,18 +3,18 @@ package emit
 type deliver[T any] func(chan T, T)
 
 func send[T any](done <-chan struct{}) deliver[T] {
-	return func(ch chan T, msg T) {
+	return func(ch chan T, v T) {
 		select {
-		case ch <- msg:
+		case ch <- v:
 		case <-done:
 		}
 	}
 }
 
 func skip[T any](_ <-chan struct{}) deliver[T] {
-	return func(ch chan T, msg T) {
+	return func(ch chan T, v T) {
 		select {
-		case ch <- msg:
+		case ch <- v:
 		default:
 		}
 	}
@@ -23,19 +23,19 @@ func skip[T any](_ <-chan struct{}) deliver[T] {
 func drain[T any](done <-chan struct{}) deliver[T] {
 	send := send[T](done)
 
-	return func(ch chan T, msg T) {
+	return func(ch chan T, v T) {
 		// prioritize non-blocking send before drain entry
 		// it avoids an unnecessary drain attempt if the channel has capacity
 		select {
-		case ch <- msg:
+		case ch <- v:
 			return
 		default:
 		}
 
 		select {
-		case ch <- msg:
+		case ch <- v:
 		case <-ch:
-			send(ch, msg)
+			send(ch, v)
 		}
 	}
 }

--- a/internal/emit/emitter.go
+++ b/internal/emit/emitter.go
@@ -17,11 +17,11 @@ func (e *emitter[T]) init() *emitter[T] {
 	return e
 }
 
-func (e *emitter[T]) emit(msg T) {
+func (e *emitter[T]) emit(v T) {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 	for out, dlv := range e.outs {
-		dlv(out, msg)
+		dlv(out, v)
 	}
 }
 

--- a/internal/emit/option.go
+++ b/internal/emit/option.go
@@ -6,6 +6,9 @@ var _ option = configure(nil)
 
 func (configure) itsOption() {}
 
+func use(s strategy) configure {
+	return func(c *config) { c.strategy = s }
+}
 func withBuffSize(size int) configure {
 	return func(c *config) {
 		if size >= 1 {
@@ -14,17 +17,13 @@ func withBuffSize(size int) configure {
 	}
 }
 
-func withStrategy(s strategy) configure {
-	return func(c *config) { c.strategy = s }
-}
-
 type setup[T any] func(*settings[T])
 
 var _ option = setup[struct{}](nil)
 
 func (s setup[T]) itsOption() {}
 
-func withFilter[T any](f filter[T]) setup[T] {
+func filtrate[T any](f filter[T]) setup[T] {
 	return func(s *settings[T]) { s.filter = f }
 }
 

--- a/internal/mux/counter.go
+++ b/internal/mux/counter.go
@@ -1,0 +1,15 @@
+package mux
+
+import "sync/atomic"
+
+type counter struct{ v int32 }
+
+func (c *counter) add(delta int) int {
+	v := atomic.AddInt32(&c.v, int32(delta))
+	return int(v)
+}
+
+func (c *counter) value() int {
+	v := atomic.LoadInt32(&c.v)
+	return int(v)
+}

--- a/internal/mux/gux.go
+++ b/internal/mux/gux.go
@@ -1,0 +1,47 @@
+package mux
+
+import "sync/atomic"
+
+var cil = (chan struct{})(nil)
+
+type gux[T any] struct {
+	count counter
+}
+
+var _ mux[struct{}] = (*gux[struct{}])(nil)
+
+func (x *gux[T]) attach(ch <-chan T, h handle[T]) detach {
+	stop := atomic.Value{}
+	stop.Store(make(chan struct{}))
+
+	x.count.add(1)
+	done := make(chan struct{})
+	go func(stop <-chan struct{}) {
+		defer close(done)
+		defer func() { x.count.add(-1) }()
+		for {
+			select {
+			case v, ok := <-ch:
+				if !ok {
+					return
+				}
+				h(v)
+			case <-stop:
+				return
+			}
+		}
+	}(stop.Load().(chan struct{}))
+
+	return func() {
+		sp := stop.Swap(cil).(chan struct{})
+		if sp == cil {
+			return // already detached
+		}
+		close(sp)
+		<-done
+	}
+}
+
+func (x *gux[T]) len() int {
+	return x.count.value()
+}

--- a/internal/mux/mux.go
+++ b/internal/mux/mux.go
@@ -1,123 +1,25 @@
 package mux
 
-import (
-	"reflect"
-	"sync"
-)
+type detach = func()
 
-type index = int
-
-const (
-	refresh index = iota
-)
-
-var indices = map[index]struct{}{
-	refresh: {},
+type mux[T any] interface {
+	attach(<-chan T, handle[T]) detach
+	len() int
 }
 
-type handle[T any] func(T)
+func create[T any](opts ...option) mux[T] {
+	cfg := new(config).init()
+	for _, opt := range opts {
+		opt(cfg)
+	}
 
-type mux[T any] struct {
-	wakeup, refresh chan struct{}
-
-	mu  sync.RWMutex
-	ins map[<-chan T]handle[T]
-}
-
-func (x *mux[T]) init() *mux[T] {
-	x.wakeup = make(chan struct{}, 1)
-	x.refresh = make(chan struct{})
-
-	x.ins = make(map[<-chan T]handle[T])
+	var x mux[T]
+	switch cfg.variant {
+	case goroutine:
+		x = new(gux[T])
+	case reflection:
+		x = new(rux[T]).init()
+	}
 
 	return x
-}
-
-func (x *mux[T]) attach(ch <-chan T, h handle[T]) (detach func()) {
-	defer x.start()
-
-	x.mu.Lock()
-	x.ins[ch] = h
-	x.mu.Unlock()
-
-	return func() {
-		defer x.start()
-
-		x.mu.Lock()
-		delete(x.ins, ch)
-		x.mu.Unlock()
-	}
-}
-
-func (x *mux[T]) len() int {
-	x.mu.RLock()
-	defer x.mu.RUnlock()
-	return len(x.ins)
-}
-
-func (x *mux[T]) start() {
-	select {
-	case x.refresh <- struct{}{}:
-	case x.wakeup <- struct{}{}:
-		go func() {
-			defer func() { <-x.wakeup }()
-			x.loop()
-		}()
-	}
-}
-
-func (x *mux[T]) loop() {
-	cases := []reflect.SelectCase{
-		refresh: {
-			Dir:  reflect.SelectRecv,
-			Chan: reflect.ValueOf(x.refresh),
-		},
-	}
-
-REFRESH:
-	for i := len(indices); i < len(cases); i++ {
-		// prevent a potential memory leak: internal array may keep a pointer
-		// to a channel that is no longer in use by the program
-		cases[i] = reflect.SelectCase{}
-	}
-	cases = cases[:len(indices)]
-	x.mu.RLock()
-	for ch := range x.ins {
-		cases = append(cases, reflect.SelectCase{
-			Dir:  reflect.SelectRecv,
-			Chan: reflect.ValueOf(ch),
-		})
-	}
-	x.mu.RUnlock()
-
-	for {
-		if len(cases) <= len(indices) {
-			return
-		}
-
-		i, rv, ok := reflect.Select(cases)
-		switch i {
-		case refresh:
-			goto REFRESH
-		}
-
-		ch := cases[i].Chan.Interface().(<-chan T)
-
-		switch {
-		case !ok: // the channel is closed
-			l := len(cases) - 1
-			cases[i], cases[l] = cases[l], reflect.SelectCase{}
-			cases = cases[:l]
-			x.mu.Lock()
-			delete(x.ins, ch)
-			x.mu.Unlock()
-		default:
-			x.mu.RLock()
-			h, hit := x.ins[ch]
-			x.mu.RUnlock()
-			if hit {
-				h(rv.Interface().(T))
-			}
-		}
-	}
 }

--- a/internal/mux/mux_test.go
+++ b/internal/mux/mux_test.go
@@ -7,155 +7,173 @@ import (
 )
 
 func TestMux(t *testing.T) {
-	t.Run("attach", func(t *testing.T) {
-		tests := []struct {
-			name  string
-			count int
-		}{
-			{name: "no one", count: 0},
-			{name: "one", count: 1},
-			{name: "few", count: 1 << 2},
-			{name: "more", count: 1 << 4},
-		}
+	variants := []struct {
+		name string
+		make func() mux[int]
+	}{
+		{
+			name: "goroutine",
+			make: func() mux[int] { return create[int](use(goroutine)) },
+		},
+		{
+			name: "reflection",
+			make: func() mux[int] { return create[int](use(reflection)) },
+		},
+	}
 
-		for _, test := range tests {
-			t.Run(test.name, func(t *testing.T) {
-				x := new(mux[struct{}]).init()
-
-				dets := make([]func(), 0, test.count)
-				for i := 0; i < test.count; i++ {
-					ch := make(chan struct{})
-					t.Cleanup(func() { close(ch) })
-
-					det := x.attach(ch, func(struct{}) {})
-					dets = append(dets, det)
+	for _, variant := range variants {
+		t.Run(variant.name, func(t *testing.T) {
+			t.Run("attach", func(t *testing.T) {
+				tests := []struct {
+					name  string
+					count int
+				}{
+					{name: "no one", count: 0},
+					{name: "one", count: 1},
+					{name: "few", count: 1 << 2},
+					{name: "more", count: 1 << 4},
 				}
 
-				if l := x.len(); l != test.count {
-					t.Errorf(
-						"at least one channel was not attached (want: %d, got: %d)",
-						test.count, l,
-					)
-				}
+				for _, test := range tests {
+					t.Run(test.name, func(t *testing.T) {
+						x := variant.make()
 
-				for _, det := range dets {
-					det()
-				}
+						dets := make([]func(), 0, test.count)
+						for i := 0; i < test.count; i++ {
+							ch := make(chan int)
+							t.Cleanup(func() { close(ch) })
 
-				if l := x.len(); l != 0 {
-					t.Errorf("some were not detached (got: %d)", l)
-				}
-			})
-		}
-	})
-
-	t.Run("handle", func(t *testing.T) {
-		tests := []struct {
-			name   string
-			ins    [][]int
-			expect map[int]int
-		}{
-			{name: "no source", ins: [][]int{}, expect: make(map[int]int)},
-			{
-				name:   "one source unique",
-				ins:    [][]int{{1, 2, 3}},
-				expect: map[int]int{1: 1, 2: 1, 3: 1},
-			},
-			{
-				name:   "one source repeat",
-				ins:    [][]int{{1, 3, 3}},
-				expect: map[int]int{1: 1, 3: 2},
-			},
-			{
-				name:   "few unique sources",
-				ins:    [][]int{{10, 20}, {30, 40}, {50}},
-				expect: map[int]int{10: 1, 20: 1, 30: 1, 40: 1, 50: 1},
-			},
-			{
-				name:   "few sources repeat across",
-				ins:    [][]int{{10, 20}, {20, 30}, {10, 30, 40}},
-				expect: map[int]int{10: 2, 20: 2, 30: 2, 40: 1},
-			},
-			{
-				name:   "few sources repeat internal",
-				ins:    [][]int{{10, 10, 20}, {30, 40, 40}, {50}},
-				expect: map[int]int{10: 2, 20: 1, 30: 1, 40: 2, 50: 1},
-			},
-			{
-				name:   "few sources mixed repeat",
-				ins:    [][]int{{10, 10, 20}, {20, 30, 30}, {10, 40}},
-				expect: map[int]int{10: 3, 20: 2, 30: 2, 40: 1},
-			},
-			{
-				name:   "few sources with empty",
-				ins:    [][]int{{10, 20}, {}, {30, 30}, {40}},
-				expect: map[int]int{10: 1, 20: 1, 30: 2, 40: 1},
-			},
-			{
-				name:   "single empty source",
-				ins:    [][]int{{}},
-				expect: make(map[int]int),
-			},
-			{
-				name:   "all empty sources",
-				ins:    [][]int{{}, {}, {}},
-				expect: make(map[int]int),
-			},
-		}
-
-		for _, test := range tests {
-			t.Run(test.name, func(t *testing.T) {
-				x := new(mux[int]).init()
-
-				total, rmp := 0, make(map[int]int, len(test.expect))
-				for k, v := range test.expect {
-					total += v
-					rmp[k] = v
-				}
-
-				mu := sync.Mutex{}
-				calls := 0
-				h := func(s int) {
-					mu.Lock()
-					defer mu.Unlock()
-					rmp[s]--
-					calls++
-				}
-
-				wg := sync.WaitGroup{}
-				for _, in := range test.ins {
-					wg.Add(1)
-					go func(in []int) {
-						defer wg.Done()
-
-						ch := make(chan int)
-						defer close(ch)
-
-						x.attach(ch, h)
-
-						for _, s := range in {
-							ch <- s
+							det := x.attach(ch, func(int) {})
+							dets = append(dets, det)
 						}
-					}(in)
-				}
-				wg.Wait()
 
-				for x.len() != 0 {
-					time.Sleep(time.Millisecond)
-				}
+						if l := x.len(); l != test.count {
+							t.Errorf(
+								"at least one channel was not attached (want: %d, got: %d)",
+								test.count, l,
+							)
+						}
 
-				if calls != total {
-					t.Errorf("less handle calls than expected (want: %d, got: %d)", total, calls)
-				}
-				for v, c := range rmp {
-					if _, hit := test.expect[v]; !hit {
-						t.Errorf("handled unexpected message (value: %d)", v)
-					}
-					if c != 0 {
-						t.Errorf("wrong c of value handle (value: %d, count: %d)", v, c)
-					}
+						for _, det := range dets {
+							det()
+						}
+
+						if l := x.len(); l != 0 {
+							t.Errorf("some were not detached (got: %d)", l)
+						}
+					})
 				}
 			})
-		}
-	})
+
+			t.Run("handle", func(t *testing.T) {
+				tests := []struct {
+					name   string
+					ins    [][]int
+					expect map[int]int
+				}{
+					{name: "no source", ins: [][]int{}, expect: make(map[int]int)},
+					{
+						name:   "one source unique",
+						ins:    [][]int{{1, 2, 3}},
+						expect: map[int]int{1: 1, 2: 1, 3: 1},
+					},
+					{
+						name:   "one source repeat",
+						ins:    [][]int{{1, 3, 3}},
+						expect: map[int]int{1: 1, 3: 2},
+					},
+					{
+						name:   "few unique sources",
+						ins:    [][]int{{10, 20}, {30, 40}, {50}},
+						expect: map[int]int{10: 1, 20: 1, 30: 1, 40: 1, 50: 1},
+					},
+					{
+						name:   "few sources repeat across",
+						ins:    [][]int{{10, 20}, {20, 30}, {10, 30, 40}},
+						expect: map[int]int{10: 2, 20: 2, 30: 2, 40: 1},
+					},
+					{
+						name:   "few sources repeat internal",
+						ins:    [][]int{{10, 10, 20}, {30, 40, 40}, {50}},
+						expect: map[int]int{10: 2, 20: 1, 30: 1, 40: 2, 50: 1},
+					},
+					{
+						name:   "few sources mixed repeat",
+						ins:    [][]int{{10, 10, 20}, {20, 30, 30}, {10, 40}},
+						expect: map[int]int{10: 3, 20: 2, 30: 2, 40: 1},
+					},
+					{
+						name:   "few sources with empty",
+						ins:    [][]int{{10, 20}, {}, {30, 30}, {40}},
+						expect: map[int]int{10: 1, 20: 1, 30: 2, 40: 1},
+					},
+					{
+						name:   "single empty source",
+						ins:    [][]int{{}},
+						expect: make(map[int]int),
+					},
+					{
+						name:   "all empty sources",
+						ins:    [][]int{{}, {}, {}},
+						expect: make(map[int]int),
+					},
+				}
+
+				for _, test := range tests {
+					t.Run(test.name, func(t *testing.T) {
+						x := variant.make()
+
+						total, rmp := 0, make(map[int]int, len(test.expect))
+						for k, v := range test.expect {
+							total += v
+							rmp[k] = v
+						}
+
+						mu := sync.Mutex{}
+						calls := 0
+						h := func(s int) {
+							mu.Lock()
+							defer mu.Unlock()
+							rmp[s]--
+							calls++
+						}
+
+						wg := sync.WaitGroup{}
+						for _, in := range test.ins {
+							wg.Add(1)
+							go func(in []int) {
+								defer wg.Done()
+
+								ch := make(chan int)
+								defer close(ch)
+
+								x.attach(ch, h)
+
+								for _, s := range in {
+									ch <- s
+								}
+							}(in)
+						}
+						wg.Wait()
+
+						for x.len() != 0 {
+							time.Sleep(time.Millisecond)
+						}
+
+						if calls != total {
+							t.Errorf("less handle calls than expected (want: %d, got: %d)", total, calls)
+						}
+						for v, c := range rmp {
+							if _, hit := test.expect[v]; !hit {
+								t.Errorf("handled unexpected message (value: %d)", v)
+							}
+							if c != 0 {
+								t.Errorf("wrong c of value handle (value: %d, count: %d)", v, c)
+							}
+						}
+					})
+				}
+			})
+		})
+	}
 }

--- a/internal/mux/option.go
+++ b/internal/mux/option.go
@@ -1,0 +1,23 @@
+package mux
+
+type variant uint8
+
+const (
+	goroutine variant = iota + 1
+	reflection
+)
+
+type config struct {
+	variant variant
+}
+
+func (c *config) init() *config {
+	c.variant = goroutine
+	return c
+}
+
+type option func(*config)
+
+func use(v variant) option {
+	return func(cfg *config) { cfg.variant = v }
+}

--- a/internal/mux/rux.go
+++ b/internal/mux/rux.go
@@ -1,0 +1,125 @@
+package mux
+
+import (
+	"reflect"
+	"sync"
+)
+
+type index = int
+
+const (
+	refresh index = iota
+)
+
+var indices = map[index]struct{}{
+	refresh: {},
+}
+
+type handle[T any] func(T)
+
+type rux[T any] struct {
+	wakeup, refresh chan struct{}
+
+	mu  sync.RWMutex
+	ins map[<-chan T]handle[T]
+}
+
+var _ mux[struct{}] = (*rux[struct{}])(nil)
+
+func (x *rux[T]) init() *rux[T] {
+	x.wakeup = make(chan struct{}, 1)
+	x.refresh = make(chan struct{})
+
+	x.ins = make(map[<-chan T]handle[T])
+
+	return x
+}
+
+func (x *rux[T]) attach(ch <-chan T, h handle[T]) detach {
+	defer x.start()
+
+	x.mu.Lock()
+	x.ins[ch] = h
+	x.mu.Unlock()
+
+	return func() {
+		defer x.start()
+
+		x.mu.Lock()
+		delete(x.ins, ch)
+		x.mu.Unlock()
+	}
+}
+
+func (x *rux[T]) len() int {
+	x.mu.RLock()
+	defer x.mu.RUnlock()
+	return len(x.ins)
+}
+
+func (x *rux[T]) start() {
+	select {
+	case x.refresh <- struct{}{}:
+	case x.wakeup <- struct{}{}:
+		go func() {
+			defer func() { <-x.wakeup }()
+			x.loop()
+		}()
+	}
+}
+
+func (x *rux[T]) loop() {
+	cases := []reflect.SelectCase{
+		refresh: {
+			Dir:  reflect.SelectRecv,
+			Chan: reflect.ValueOf(x.refresh),
+		},
+	}
+
+REFRESH:
+	for i := len(indices); i < len(cases); i++ {
+		// prevent a potential memory leak: internal array may keep a pointer
+		// to a channel that is no longer in use by the program
+		cases[i] = reflect.SelectCase{}
+	}
+	cases = cases[:len(indices)]
+	x.mu.RLock()
+	for ch := range x.ins {
+		cases = append(cases, reflect.SelectCase{
+			Dir:  reflect.SelectRecv,
+			Chan: reflect.ValueOf(ch),
+		})
+	}
+	x.mu.RUnlock()
+
+	for {
+		if len(cases) <= len(indices) {
+			return
+		}
+
+		i, rv, ok := reflect.Select(cases)
+		switch i {
+		case refresh:
+			goto REFRESH
+		}
+
+		ch := cases[i].Chan.Interface().(<-chan T)
+
+		switch {
+		case !ok: // the channel is closed
+			l := len(cases) - 1
+			cases[i], cases[l] = cases[l], reflect.SelectCase{}
+			cases = cases[:l]
+			x.mu.Lock()
+			delete(x.ins, ch)
+			x.mu.Unlock()
+		default:
+			x.mu.RLock()
+			h, hit := x.ins[ch]
+			x.mu.RUnlock()
+			if hit {
+				h(rv.Interface().(T))
+			}
+		}
+	}
+}


### PR DESCRIPTION
This pull request introduces several enhancements and refactorings to the `Castix` library, including the addition of configuration options, improved benchmarking, and a significant refactor of the internal `mux` implementation. The changes aim to improve flexibility, maintainability, and clarity in the codebase.

### Enhancements to `Castix` configuration:
* [`castix.go`](diffhunk://#diff-eae85305329c12730b17cf54935005bbfef7dacb95354a39370bb4120352da6bL38-R46): Added support for configuration options in the `New` function by introducing the `Option` type. This allows users to customize the behavior of `Castix` instances, such as specifying input/output strategies.

### Improved benchmarking:
* [`castix_test.go`](diffhunk://#diff-50f43e41f50ad89376385e6dd1d1cc215d4973e15f4090ba7725b2f6864566caR28-R59): Enhanced the `BenchmarkCastix` function to test multiple variants (`goroutine` and `reflection`) of `Castix` behavior, enabling more comprehensive performance comparisons. [[1]](diffhunk://#diff-50f43e41f50ad89376385e6dd1d1cc215d4973e15f4090ba7725b2f6864566caR28-R59) [[2]](diffhunk://#diff-50f43e41f50ad89376385e6dd1d1cc215d4973e15f4090ba7725b2f6864566caL92-R108) [[3]](diffhunk://#diff-50f43e41f50ad89376385e6dd1d1cc215d4973e15f4090ba7725b2f6864566caL136-R152) [[4]](diffhunk://#diff-50f43e41f50ad89376385e6dd1d1cc215d4973e15f4090ba7725b2f6864566caR202-R203)

### Refactor of `mux` implementation:
* [`internal/mux/mux.go`](diffhunk://#diff-398fff8212985c9fc4096098c26da7f6715a3cf4480ff12c683d0716a885498fL3-R26): Replaced the previous `mux` implementation with a strategy-based design (`gux` and `rux` variants). This simplifies the code while providing flexibility for different concurrency models.
* [`internal/mux/gux.go`](diffhunk://#diff-928c3802ee00da7225a3c8d10646f07f4baa098112782d3657984dcef16adbbdR1-R47): Added the `gux` implementation for `mux`, which uses goroutines for managing channels and handlers.
* [`internal/mux/counter.go`](diffhunk://#diff-f5e051870aafb066c384344f765b4739c3abc80820dabc0226aa83e83b3aa1b4R1-R15): Introduced a thread-safe `counter` utility to manage counts in the `mux` implementation.

### Refactor of `emit` module:
* [`internal/emit/bridge.go`](diffhunk://#diff-c98308439ee8244bbce6fb6fa6fc0119232f5d6c891b50414b03448fbb2c0a04L18-R18): Renamed methods and parameters to improve clarity (`Pass` to `emit`, `withStrategy` to `use`, etc.), and adjusted the `Watch` method to use new naming conventions. [[1]](diffhunk://#diff-c98308439ee8244bbce6fb6fa6fc0119232f5d6c891b50414b03448fbb2c0a04L18-R18) [[2]](diffhunk://#diff-c98308439ee8244bbce6fb6fa6fc0119232f5d6c891b50414b03448fbb2c0a04L27-R31)
* [`internal/emit/delivery.go`](diffhunk://#diff-1acba367c4d72d895e38b00cf47b936b0b3666e5d91af2254f223dc76b45380bL6-R17): Updated delivery-related functions to use clearer parameter names (`msg` to `v`) and improved readability. [[1]](diffhunk://#diff-1acba367c4d72d895e38b00cf47b936b0b3666e5d91af2254f223dc76b45380bL6-R17) [[2]](diffhunk://#diff-1acba367c4d72d895e38b00cf47b936b0b3666e5d91af2254f223dc76b45380bL26-R38)
* [`internal/emit/option.go`](diffhunk://#diff-7c308d054fcf5563ec97aa032bfe4fc46f6d80af0b3cb0800693e83af9afa185R9-R11): Refactored option-related methods (`withStrategy` to `use`, `withFilter` to `filtrate`) for consistency with the new naming conventions. [[1]](diffhunk://#diff-7c308d054fcf5563ec97aa032bfe4fc46f6d80af0b3cb0800693e83af9afa185R9-R11) [[2]](diffhunk://#diff-7c308d054fcf5563ec97aa032bfe4fc46f6d80af0b3cb0800693e83af9afa185L17-R26)

### Minor changes:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L8-R10): Reformatted text for better readability.
* [`internal/bridge/type.go`](diffhunk://#diff-9cc44b6c974a8d5afa618cf9f2411fa0fe0562488d8f7ac871c1702606163335L3-R3): Changed `Leave` type alias for better compatibility.
* `internal/emit/emitter.go` and `internal/emit/emitter_test.go`: Updated variable names and method calls for clarity and consistency. [[1]](diffhunk://#diff-ca0c7eb258355326bf9cea76c79d7887e0bac055055c060e1ab1c77958e335eeL20-R24) [[2]](diffhunk://#diff-2467893de6e72413ad88f240eae16ca5c97010c854f43d4c8d2ea88986c2ef11L12-R12) [[3]](diffhunk://#diff-2467893de6e72413ad88f240eae16ca5c97010c854f43d4c8d2ea88986c2ef11L38-R39) [[4]](diffhunk://#diff-2467893de6e72413ad88f240eae16ca5c97010c854f43d4c8d2ea88986c2ef11L48-R54) [[5]](diffhunk://#diff-2467893de6e72413ad88f240eae16ca5c97010c854f43d4c8d2ea88986c2ef11L71-R71) [[6]](diffhunk://#diff-2467893de6e72413ad88f240eae16ca5c97010c854f43d4c8d2ea88986c2ef11L84-R92) [[7]](diffhunk://#diff-2467893de6e72413ad88f240eae16ca5c97010c854f43d4c8d2ea88986c2ef11L104-R104) [[8]](diffhunk://#diff-2467893de6e72413ad88f240eae16ca5c97010c854f43d4c8d2ea88986c2ef11L117-R134)

These changes collectively enhance the usability, performance, and maintainability of the `Castix` library.